### PR TITLE
ci: add automated semantic-release on master

### DIFF
--- a/.github/workflows/1-tests.yml
+++ b/.github/workflows/1-tests.yml
@@ -3,7 +3,6 @@ name: 1️⃣ Tests
 on:
   push:
     branches: [ main, master ]  # Seulement les branches principales
-    tags: [ '*' ]             # Tags de version (1.0.0, 2.1.3, etc.)
   pull_request:
     branches: [ main, master ]  # Pull requests vers les branches principales
   workflow_dispatch:             # Déclenchement manuel si besoin

--- a/.github/workflows/4-release.yml
+++ b/.github/workflows/4-release.yml
@@ -1,0 +1,57 @@
+name: 4️⃣ Release
+
+on:
+  workflow_run:
+    workflows: ["1️⃣ Tests"]
+    types:
+      - completed
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install semantic-release and plugins
+        run: |
+          npm install --no-save \
+            semantic-release \
+            @semantic-release/changelog \
+            @semantic-release/git \
+            @semantic-release/exec \
+            @semantic-release/github \
+            conventional-changelog-conventionalcommits
+
+      - name: Run semantic-release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,61 @@
+{
+  "branches": ["master", "main"],
+  "tagFormat": "${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "breaking": true, "release": "major" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "✨ Features" },
+            { "type": "fix", "section": "🐛 Bug Fixes" },
+            { "type": "perf", "section": "⚡ Performance Improvements" },
+            { "type": "refactor", "section": "♻️ Refactoring", "hidden": false },
+            { "type": "docs", "section": "📚 Documentation", "hidden": false },
+            { "type": "chore", "hidden": true },
+            { "type": "test", "hidden": true }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "bash scripts/update-versions.sh ${nextRelease.version}"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "klask-react/package.json",
+          "klask-rs/Cargo.toml",
+          "charts/klask/Chart.yaml"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+VERSION="$1"
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+echo "Updating versions to $VERSION..."
+
+# Update Cargo.toml - only the [package] section version (first occurrence)
+sed -i "0,/^version = /s/version = \".*\"/version = \"$VERSION\"/" klask-rs/Cargo.toml
+grep -q "version = \"$VERSION\"" klask-rs/Cargo.toml || { echo "❌ Failed to update Cargo.toml"; exit 1; }
+echo "  ✅ klask-rs/Cargo.toml"
+
+# Update package.json version using node
+node -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('klask-react/package.json', 'utf8'));
+pkg.version = process.argv[1];
+fs.writeFileSync('klask-react/package.json', JSON.stringify(pkg, null, 2) + '\n');
+" "$VERSION"
+node -e "const p=require('./klask-react/package.json'); if(p.version !== process.argv[1]) process.exit(1);" "$VERSION" || { echo "❌ Failed to update package.json"; exit 1; }
+echo "  ✅ klask-react/package.json"
+
+# Update Chart.yaml version and appVersion
+sed -i "s/^version:.*/version: $VERSION/" charts/klask/Chart.yaml
+sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" charts/klask/Chart.yaml
+grep -q "^version: $VERSION" charts/klask/Chart.yaml || { echo "❌ Failed to update Chart.yaml version"; exit 1; }
+echo "  ✅ charts/klask/Chart.yaml"
+
+echo "✅ All versions updated to $VERSION"


### PR DESCRIPTION
- Add 4-release.yml workflow triggered after tests pass on master
- Add .releaserc.json with conventional commits analyzer, changelog, exec (version bump), git commit and github release plugins
- Add scripts/update-versions.sh to sync versions across Cargo.toml, package.json and charts/klask/Chart.yaml
- Remove redundant tags trigger from 1-tests.yml (tests already run on branch push before the tag is created)

Versioning rules: fix/perf -> patch, feat -> minor, breaking -> major chore/docs/refactor commits do not trigger a release.

Requires RELEASE_TOKEN secret (PAT) to allow semantic-release to push version bump commits and trigger downstream workflows.