### PR TITLE
ci: fix docker :latest tag and duplicate helm publish

### DIFF
--- a/.github/workflows/3-publish-helm.yml
+++ b/.github/workflows/3-publish-helm.yml
@@ -8,7 +8,7 @@ on:
 
   workflow_dispatch:  # Permettre déclenchement manuel
   workflow_run:
-    workflows: ["2️⃣ Build images", "Release"]
+    workflows: ["Release"]
     types:
       - completed
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
         tags: |
           ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ steps.version.outputs.tag }}
           ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.FRONTEND_IMAGE_NAME }}:stable
+          ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.FRONTEND_IMAGE_NAME }}:latest
         build-args: |
           VITE_APP_VERSION=${{ steps.build-meta.outputs.version }}
           VITE_APP_COMMIT=${{ steps.build-meta.outputs.commit }}
@@ -80,6 +81,7 @@ jobs:
         tags: |
           ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.BACKEND_IMAGE_NAME }}:${{ steps.version.outputs.tag }}
           ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.BACKEND_IMAGE_NAME }}:stable
+          ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.BACKEND_IMAGE_NAME }}:latest
         build-args: |
           KLASK_VERSION=${{ steps.build-meta.outputs.version }}
           GIT_COMMIT_HASH=${{ steps.build-meta.outputs.commit }}


### PR DESCRIPTION
## Summary

- **`:latest` tag désynchronisé** : après une release, `:latest` pointait sur le commit de merge (avant le bump de version par semantic-release), donc `VITE_APP_VERSION` et `KLASK_VERSION` baked dans l'image affichaient l'ancienne version. `release.yml` pousse maintenant aussi `:latest` → `:latest` = `:stable` = `:X.Y.Z` après chaque release.
- **Helm Chart publié en double** : `3-publish-helm.yml` était déclenché à la fois par l'event `release` et par la completion de `2-build-images` via `workflow_run`. Suppression du trigger `2-build-images` — seul le workflow `Release` suffit.

## Comportement attendu après merge

| Tag | Pointe sur |
|-----|-----------|
| `:latest` | dernier commit de release (= `:stable`) |
| `:stable` | dernier commit de release |
| `:X.Y.Z` | commit de release correspondant |
| `:master` | dernier commit sur master (dev, peut être en avance sur la release) |