### PR TITLE
feat(mcp): add MCP server exposing code search to AI agents

### DIFF
--- a/.github/workflows/1-tests.yml
+++ b/.github/workflows/1-tests.yml
@@ -104,3 +104,13 @@ jobs:
       run: cargo test
       env:
         DATABASE_URL: postgres://postgres:postgres@localhost:5432/klask_test
+
+    # Tests marked #[ignore = "Requires PostgreSQL database"] are skipped by
+    # plain `cargo test`; run the suites known to be green against the service
+    # container. (admin_endpoints_test is excluded: its ignored tests are stale.)
+    - name: Run PostgreSQL-backed integration tests
+      run: |
+        cargo test --test mcp_test -- --ignored
+        cargo test --test search_service_test -- --ignored
+      env:
+        DATABASE_URL: postgres://postgres:postgres@localhost:5432/klask_test

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -125,7 +125,7 @@ JWT_SECRET=your-super-secret-jwt-key-change-in-production
 JWT_EXPIRES_IN=24h
 
 # Search Index
-SEARCH_INDEX_PATH=./search_index
+SEARCH_INDEX_DIR=./search_index
 
 # Crawler
 TEMP_DIR=./temp_crawl
@@ -186,7 +186,7 @@ npm run build
    - Clear browser localStorage if needed
 
 4. **Search Index Errors**
-   - Ensure SEARCH_INDEX_PATH directory exists
+   - Ensure SEARCH_INDEX_DIR directory exists
    - Check write permissions
    - Re-run crawler if index is corrupted
 

--- a/docs/MCP_SERVER_PLAN.md
+++ b/docs/MCP_SERVER_PLAN.md
@@ -1,0 +1,174 @@
+# 🔌 MCP Server Plan — Klask as a Code-Search Tool for AI Agents
+
+## 1. Goal & Positioning
+
+Expose Klask as an **MCP (Model Context Protocol) server** so that AI coding agents
+(Claude Code, Cursor, Copilot, custom agents) can use Klask as their **cross-repository
+code-search backend**.
+
+**Why this is the killer feature:**
+- Coding agents are blind outside the repo they are launched in. Klask already indexes
+  *all* the organization's repositories and branches.
+- Self-hosted + Rust = private, fast, zero data leaves the infra. This is exactly what
+  enterprises want for their AI agents.
+- The search API already exists — the MCP server is a thin protocol adapter, not a new
+  engine.
+
+**Target UX** (Claude Code example):
+
+```bash
+claude mcp add --transport http klask http://klask.internal:3000/mcp \
+  --header "Authorization: Bearer <token>"
+```
+
+Then the agent can answer: *"How do the other services call the billing API?"* by
+searching the entire indexed codebase.
+
+---
+
+## 2. Technical Decisions
+
+### 2.1 Transport: Streamable HTTP (stateless), mounted in the existing Axum server
+
+- Single endpoint **`POST /mcp`** on the existing backend (port 3000). No separate
+  process, no separate deployment, Helm chart unchanged.
+- **Stateless JSON responses**: the MCP Streamable HTTP spec allows the server to
+  answer each POST with a plain `application/json` JSON-RPC response (no SSE needed
+  for a tools-only server). No session state to manage.
+- `GET /mcp` → `405 Method Not Allowed` (no server-initiated streams in v1).
+- stdio transport is **not needed**: Klask is a long-running server; HTTP is the
+  natural transport and is supported by all major MCP clients.
+
+### 2.2 Protocol implementation: hand-rolled (no new dependency)
+
+A tools-only stateless MCP server needs exactly 5 JSON-RPC methods:
+`initialize`, `notifications/initialized`, `tools/list`, `tools/call`, `ping`.
+
+We implement them directly (~300 lines with types) instead of pulling the `rmcp` SDK:
+- Consistent with the project's lean-dependency philosophy (pure Rust, no OpenSSL, gix
+  instead of git2).
+- No coupling to a fast-moving SDK and its axum version requirements.
+- Full control over auth integration (reuse the existing `AuthenticatedUser` extractor).
+
+Protocol version: negotiate `2025-06-18` (fall back to echoing older client versions —
+the subset we use is identical).
+
+### 2.3 Authentication: reuse JWT Bearer (v1), API keys later (v2)
+
+- The existing `AuthenticatedUser` extractor already accepts
+  `Authorization: Bearer <JWT>` — MCP clients send custom headers, so **v1 works with a
+  standard user token** and zero new code.
+- **v2 follow-up**: long-lived personal API tokens (`klask_pat_…`, hashed in DB, scoped
+  read-only, revocable from the user profile page) because JWTs expire
+  (`jwt_expires_in`, default 24h) which is annoying for an agent config. This is a
+  separate, independent PR.
+
+---
+
+## 3. Tools Exposed (v1)
+
+| Tool | Description | Backed by |
+|---|---|---|
+| `search_code` | Full-text/regex search across all indexed repos with filters | `SearchService::search()` |
+| `get_file` | Retrieve full file content (with optional line range) | `get_file_by_doc_address()` / `get_file_by_id()` |
+| `list_repositories` | List indexed repositories (name, url, type, last crawl) | `RepositoryRepository::list_repositories()` |
+| `get_search_facets` | Discover available projects / branches / extensions (to scope searches) | `SearchService::search()` with `include_facets` |
+
+### 3.1 `search_code`
+
+Input schema (all filters optional):
+```json
+{
+  "query":        "string (required) — terms, phrase, or regex",
+  "projects":     ["array of project names"],
+  "versions":     ["array of branches/tags"],
+  "extensions":   ["array, e.g. rs, ts, java"],
+  "regex":        "boolean (default false)",
+  "case_sensitive": "boolean (default false)",
+  "limit":        "integer 1-100 (default 20)",
+  "page":         "integer (default 1)"
+}
+```
+Output: JSON text content — `total` + array of `{project, version, path, line_number,
+score, snippet, doc_address, file_id}`. `doc_address` is the handle for `get_file`.
+
+Design notes:
+- Filters are **arrays** in the schema (agent-friendly), joined to the comma-separated
+  strings the service expects.
+- `limit` capped at 100 (agents don't paginate like humans; protect their context
+  window).
+- Reuse `regex_validator::validate_regex_pattern` when `regex: true`.
+
+### 3.2 `get_file`
+
+Input: `doc_address` **or** `file_id`, plus optional `start_line` / `end_line`.
+Output: file metadata + content. Content is truncated beyond a max line count
+(default 2000) with an explicit `truncated: true` marker so the agent knows to request
+a line range.
+
+### 3.3 `list_repositories`
+
+No input. Output: array of `{name, url, repository_type, enabled, last_crawled}`.
+Read-only projection — **no tokens, no crawl config** ever exposed.
+
+### 3.4 `get_search_facets`
+
+Optional `query` + same filters as `search_code`. Output: facet counts for
+repositories, projects, versions, extensions. Lets an agent discover *what exists*
+before searching ("which repos have Kotlin files?").
+
+---
+
+## 4. File Layout & Integration
+
+```
+klask-rs/src/
+├── mcp/
+│   ├── mod.rs        # create_router(), POST handler, method dispatch
+│   ├── protocol.rs   # JSON-RPC 2.0 + MCP types (requests, responses, errors)
+│   └── tools.rs      # Tool definitions (JSON Schemas) + handlers calling services
+└── main.rs           # .route("/mcp", ...) at root level (outside /api)
+```
+
+- Mounted at **`/mcp`** (root), not under `/api`: it is a protocol endpoint, not a REST
+  resource, and this matches MCP conventions.
+- Handlers receive `State<AppState>` + `AuthenticatedUser` exactly like REST endpoints;
+  tool logic calls `SearchService` directly (no internal HTTP hop).
+- JSON-RPC errors: `-32700` parse error, `-32601` method not found, `-32602` invalid
+  params; tool execution failures use `tools/call` result with `isError: true`
+  (per MCP spec), not JSON-RPC errors.
+
+---
+
+## 5. Testing Strategy
+
+1. **Unit tests** (`src/mcp/`): JSON-RPC parsing, schema serialization of each tool,
+   filter array → comma-string conversion, line-range/truncation logic.
+2. **Integration test** (`tests/mcp_test.rs`, `axum-test` + `TestDatabase` + temp
+   Tantivy index, same pattern as existing API tests):
+   - full handshake: `initialize` → `notifications/initialized` (202) → `tools/list`;
+   - `tools/call search_code` after indexing fixture files — verify hits and snippets;
+   - `tools/call get_file` round-trip via `doc_address` from search results;
+   - auth: request without Bearer → 401;
+   - unknown method → `-32601`; malformed JSON → `-32700`.
+3. **Manual smoke test**: register the server in Claude Code and run a real search.
+
+---
+
+## 6. Rollout Phases
+
+| Phase | Content | Status |
+|---|---|---|
+| **1** | MCP endpoint + 4 tools + tests + this doc | 🚧 this PR |
+| **2** | Personal API tokens (long-lived, revocable, read-only scope) | planned |
+| **3** | `semantic_search` tool / `mode` param once hybrid search lands (see [SEMANTIC_SEARCH_PLAN.md](SEMANTIC_SEARCH_PLAN.md)) | planned |
+| **4** | Listing on MCP server directories + README section + demo GIF | planned |
+
+## 7. Risks & Mitigations
+
+- **Token-hungry responses** → snippets only in search results, capped limits,
+  truncation markers in `get_file`.
+- **Search exposes all repos to any authenticated user** → matches current Klask
+  semantics (the web UI already does); revisit if per-repo ACLs ever land.
+- **MCP spec evolution** → surface is tiny and versioned; we negotiate the protocol
+  version at `initialize`.

--- a/klask-react/package-lock.json
+++ b/klask-react/package-lock.json
@@ -48,7 +48,6 @@
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/ui": "^4.1.8",
         "autoprefixer": "^10.4.22",
-        "baseline-browser-mapping": "^2.10.37",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",

--- a/klask-react/package-lock.json
+++ b/klask-react/package-lock.json
@@ -48,6 +48,7 @@
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/ui": "^4.1.8",
         "autoprefixer": "^10.4.22",
+        "baseline-browser-mapping": "^2.10.37",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -3192,13 +3193,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
-      "integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {

--- a/klask-react/package.json
+++ b/klask-react/package.json
@@ -58,6 +58,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
     "autoprefixer": "^10.4.22",
+    "baseline-browser-mapping": "^2.10.37",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/klask-react/package.json
+++ b/klask-react/package.json
@@ -58,7 +58,6 @@
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
     "autoprefixer": "^10.4.22",
-    "baseline-browser-mapping": "^2.10.37",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/klask-react/src/App.tsx
+++ b/klask-react/src/App.tsx
@@ -29,6 +29,7 @@ const IndexManagement = React.lazy(() => import('./features/admin/IndexManagemen
 const LoginPage = React.lazy(() => import('./features/auth/LoginPage'));
 const RegisterPage = React.lazy(() => import('./features/auth/RegisterPage'));
 const ProfilePage = React.lazy(() => import('./features/auth/ProfilePage'));
+const ApiTokensPage = React.lazy(() => import('./features/auth/tokens/ApiTokensPage'));
 const SetupPage = React.lazy(() => import('./features/auth/SetupPage'));
 const SetupRedirect = React.lazy(() => import('./components/setup/SetupRedirect'));
 const SyntaxHighlighterTest = React.lazy(() => import('./components/test/SyntaxHighlighterTest'));
@@ -162,15 +163,25 @@ function App() {
               />
               
               {/* Profile route */}
-              <Route 
-                path="profile" 
+              <Route
+                path="profile"
                 element={
                   <Suspense fallback={<LoadingSpinner />}>
                     <ProfilePage />
                   </Suspense>
-                } 
+                }
               />
-              
+
+              {/* API Tokens route */}
+              <Route
+                path="settings/api-tokens"
+                element={
+                  <Suspense fallback={<LoadingSpinner />}>
+                    <ApiTokensPage />
+                  </Suspense>
+                }
+              />
+
               {/* Test route for syntax highlighter */}
               <Route 
                 path="test/syntax-highlighter" 

--- a/klask-react/src/api/__tests__/apiTokens.test.ts
+++ b/klask-react/src/api/__tests__/apiTokens.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useApiTokens, useCreateApiToken, useRevokeApiToken } from '../apiTokens';
+import * as apiTokensModule from '../apiTokens';
+
+// Mock react-query
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(),
+  useQueryClient: vi.fn(),
+}));
+
+// Mock the api module
+vi.mock('../../lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('API Tokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should export useApiTokens hook', () => {
+    expect(typeof apiTokensModule.useApiTokens).toBe('function');
+  });
+
+  it('should export useCreateApiToken hook', () => {
+    expect(typeof apiTokensModule.useCreateApiToken).toBe('function');
+  });
+
+  it('should export useRevokeApiToken hook', () => {
+    expect(typeof apiTokensModule.useRevokeApiToken).toBe('function');
+  });
+});

--- a/klask-react/src/api/__tests__/apiTokens.test.ts
+++ b/klask-react/src/api/__tests__/apiTokens.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useApiTokens, useCreateApiToken, useRevokeApiToken } from '../apiTokens';
 import * as apiTokensModule from '../apiTokens';
 
 // Mock react-query

--- a/klask-react/src/api/apiTokens.ts
+++ b/klask-react/src/api/apiTokens.ts
@@ -16,6 +16,7 @@ function validateApiTokenInfo(data: unknown): ApiTokenInfo {
     typeof obj?.name !== 'string' ||
     typeof obj?.token_prefix !== 'string' ||
     typeof obj?.scope !== 'string' ||
+    typeof obj?.active !== 'boolean' ||
     typeof obj?.created_at !== 'string'
   ) {
     throw new Error('Invalid ApiTokenInfo structure from backend');

--- a/klask-react/src/api/apiTokens.ts
+++ b/klask-react/src/api/apiTokens.ts
@@ -26,9 +26,17 @@ function validateApiTokenInfo(data: unknown): ApiTokenInfo {
 
 function validateApiTokenInfoArray(data: unknown): ApiTokenInfo[] {
   if (!Array.isArray(data)) {
+    console.error('Expected array but got:', typeof data, data);
     throw new Error('Expected array of tokens');
   }
-  return data.map(validateApiTokenInfo);
+  return data.map((item, index) => {
+    try {
+      return validateApiTokenInfo(item);
+    } catch (e) {
+      console.error(`Failed to validate token at index ${index}:`, item, e);
+      throw e;
+    }
+  });
 }
 
 function validateCreateTokenResponse(data: unknown): CreateTokenResponse {
@@ -47,17 +55,17 @@ function validateCreateTokenResponse(data: unknown): CreateTokenResponse {
 
 // Fetch Functions
 async function fetchApiTokens(): Promise<ApiTokenInfo[]> {
-  const response = await api.get<ApiTokenInfo[]>('/api/user/tokens');
+  const response = await api.get<ApiTokenInfo[]>('/api/users/tokens');
   return validateApiTokenInfoArray(response);
 }
 
 async function createApiToken(name: string): Promise<CreateTokenResponse> {
-  const response = await api.post<CreateTokenResponse>('/api/user/tokens', { name });
+  const response = await api.post<CreateTokenResponse>('/api/users/tokens', { name });
   return validateCreateTokenResponse(response);
 }
 
 async function revokeApiToken(tokenId: string): Promise<void> {
-  await api.delete(`/api/user/tokens/${tokenId}`);
+  await api.delete(`/api/users/tokens/${tokenId}`);
 }
 
 /**

--- a/klask-react/src/api/apiTokens.ts
+++ b/klask-react/src/api/apiTokens.ts
@@ -1,0 +1,103 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { ApiTokenInfo, CreateTokenResponse } from '../types';
+
+// Query Keys
+const apiTokensKeys = {
+  all: ['api-tokens'] as const,
+  list: () => [...apiTokensKeys.all, 'list'] as const,
+};
+
+// Response validators
+function validateApiTokenInfo(data: unknown): ApiTokenInfo {
+  const obj = data as Record<string, unknown>;
+  if (
+    typeof obj?.id !== 'string' ||
+    typeof obj?.name !== 'string' ||
+    typeof obj?.token_prefix !== 'string' ||
+    typeof obj?.scope !== 'string' ||
+    typeof obj?.created_at !== 'string'
+  ) {
+    throw new Error('Invalid ApiTokenInfo structure from backend');
+  }
+  return obj as unknown as ApiTokenInfo;
+}
+
+function validateApiTokenInfoArray(data: unknown): ApiTokenInfo[] {
+  if (!Array.isArray(data)) {
+    throw new Error('Expected array of tokens');
+  }
+  return data.map(validateApiTokenInfo);
+}
+
+function validateCreateTokenResponse(data: unknown): CreateTokenResponse {
+  const obj = data as Record<string, unknown>;
+  if (
+    typeof obj?.id !== 'string' ||
+    typeof obj?.token !== 'string' ||
+    typeof obj?.token_prefix !== 'string' ||
+    typeof obj?.name !== 'string' ||
+    typeof obj?.created_at !== 'string'
+  ) {
+    throw new Error('Invalid CreateTokenResponse structure from backend');
+  }
+  return obj as unknown as CreateTokenResponse;
+}
+
+// Fetch Functions
+async function fetchApiTokens(): Promise<ApiTokenInfo[]> {
+  const response = await api.get<ApiTokenInfo[]>('/api/user/tokens');
+  return validateApiTokenInfoArray(response);
+}
+
+async function createApiToken(name: string): Promise<CreateTokenResponse> {
+  const response = await api.post<CreateTokenResponse>('/api/user/tokens', { name });
+  return validateCreateTokenResponse(response);
+}
+
+async function revokeApiToken(tokenId: string): Promise<void> {
+  await api.delete(`/api/user/tokens/${tokenId}`);
+}
+
+/**
+ * Hook to fetch all API tokens for the current user
+ */
+export function useApiTokens() {
+  return useQuery({
+    queryKey: apiTokensKeys.list(),
+    queryFn: fetchApiTokens,
+    staleTime: 5 * 60000, // 5 minutes
+    retry: 2,
+    retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+}
+
+/**
+ * Hook to create a new API token
+ */
+export function useCreateApiToken() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (name: string) => createApiToken(name),
+    onSuccess: () => {
+      // Invalidate tokens list to refetch updated data
+      queryClient.invalidateQueries({ queryKey: apiTokensKeys.list() });
+    },
+  });
+}
+
+/**
+ * Hook to revoke an API token
+ */
+export function useRevokeApiToken() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (tokenId: string) => revokeApiToken(tokenId),
+    onSuccess: () => {
+      // Invalidate tokens list to refetch updated data
+      queryClient.invalidateQueries({ queryKey: apiTokensKeys.list() });
+    },
+  });
+}

--- a/klask-react/src/components/common/ProtectedRoute.tsx
+++ b/klask-react/src/components/common/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { authSelectors } from '../../stores/auth-store';
+import { authSelectors, useIsHydrated } from '../../stores/auth-store';
 import { FullPageSpinner } from '../ui/LoadingSpinner';
 
 interface ProtectedRouteProps {
@@ -8,21 +8,23 @@ interface ProtectedRouteProps {
 }
 
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const isHydrated = useIsHydrated();
   const isAuthenticated = authSelectors.isAuthenticated();
   const isLoading = authSelectors.isLoading();
   const location = useLocation();
 
-  if (isLoading) {
+  // Wait for Zustand to rehydrate from localStorage
+  if (!isHydrated || isLoading) {
     return <FullPageSpinner message="Authenticating..." />;
   }
 
   if (!isAuthenticated) {
     // Redirect to login page with return url
     return (
-      <Navigate 
-        to="/login" 
-        state={{ from: location }} 
-        replace 
+      <Navigate
+        to="/login"
+        state={{ from: location }}
+        replace
       />
     );
   }

--- a/klask-react/src/features/auth/ProfilePage.tsx
+++ b/klask-react/src/features/auth/ProfilePage.tsx
@@ -7,8 +7,9 @@ import PreferencesSection from './components/PreferencesSection';
 import SecuritySection from './components/SecuritySection';
 import ActivitySection from './components/ActivitySection';
 import DeleteAccountModal from './components/DeleteAccountModal';
+import { ApiTokensPage } from './tokens/ApiTokensPage';
 
-type TabType = 'info' | 'prefs' | 'security' | 'activity';
+type TabType = 'info' | 'prefs' | 'security' | 'activity' | 'tokens';
 
 interface TabConfig {
   id: TabType;
@@ -66,6 +67,19 @@ const ProfilePage: React.FC = () => {
         </svg>
       ),
     },
+    {
+      id: 'tokens',
+      label: 'API Tokens',
+      icon: (
+        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+          <path
+            fillRule="evenodd"
+            d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
   ];
 
   if (!user) {
@@ -118,6 +132,7 @@ const ProfilePage: React.FC = () => {
             {activeTab === 'prefs' && <PreferencesSection />}
             {activeTab === 'security' && <SecuritySection />}
             {activeTab === 'activity' && <ActivitySection />}
+            {activeTab === 'tokens' && <ApiTokensPage />}
           </div>
         </div>
 

--- a/klask-react/src/features/auth/tokens/ApiTokensPage.tsx
+++ b/klask-react/src/features/auth/tokens/ApiTokensPage.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import ErrorBoundary from '../../../components/ErrorBoundary';
+import CreateTokenModal from './CreateTokenModal';
+import TokensList from './TokensList';
+
+const ApiTokensPage: React.FC = () => {
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+
+  return (
+    <ErrorBoundary onError={(error) => console.error('ApiTokensPage error:', error)}>
+      <div className="max-w-4xl mx-auto py-8 px-4 space-y-8">
+        {/* Page Header */}
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">API Tokens</h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">
+            Manage personal API tokens to authenticate with the Klask API
+          </p>
+        </div>
+
+        {/* Info Box */}
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
+          <div className="flex gap-4">
+            <svg className="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zm-11-1a1 1 0 11-2 0 1 1 0 012 0zM8 7a1 1 0 100-2 1 1 0 000 2zm5-1a1 1 0 11-2 0 1 1 0 012 0zM14 7a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+            </svg>
+            <div>
+              <h3 className="font-medium text-blue-900 dark:text-blue-300">API Token Documentation</h3>
+              <p className="text-sm text-blue-700 dark:text-blue-400 mt-1">
+                Use personal API tokens to authenticate with the Klask API. Each token has limited scope and can be revoked individually without affecting other tokens.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Active Tokens Section */}
+        <div className="space-y-4">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Active Tokens</h2>
+              <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">View and manage your API tokens</p>
+            </div>
+            <button
+              onClick={() => setCreateModalOpen(true)}
+              className="px-6 py-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 text-white rounded-lg transition font-medium flex items-center gap-2 flex-shrink-0"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              Create New Token
+            </button>
+          </div>
+
+          {/* Tokens List */}
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+            <TokensList />
+          </div>
+        </div>
+
+        {/* Security Notes */}
+        <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-6">
+          <h3 className="font-bold text-yellow-900 dark:text-yellow-300 mb-4">Security Best Practices</h3>
+          <ul className="space-y-2 text-sm text-yellow-700 dark:text-yellow-400">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0">•</span>
+              <span>Never share your API tokens with others or commit them to version control</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0">•</span>
+              <span>Rotate tokens regularly and revoke tokens you no longer use</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0">•</span>
+              <span>Use short-lived tokens when possible for scripts and CI/CD pipelines</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0">•</span>
+              <span>Monitor token usage in the "Last Used" column to detect unauthorized access</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0">•</span>
+              <span>If a token is compromised, revoke it immediately</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Create Token Modal */}
+      <CreateTokenModal isOpen={createModalOpen} onClose={() => setCreateModalOpen(false)} />
+    </ErrorBoundary>
+  );
+};
+
+export default ApiTokensPage;

--- a/klask-react/src/features/auth/tokens/ApiTokensPage.tsx
+++ b/klask-react/src/features/auth/tokens/ApiTokensPage.tsx
@@ -91,3 +91,4 @@ const ApiTokensPage: React.FC = () => {
 };
 
 export default ApiTokensPage;
+export { ApiTokensPage };

--- a/klask-react/src/features/auth/tokens/CreateTokenModal.tsx
+++ b/klask-react/src/features/auth/tokens/CreateTokenModal.tsx
@@ -1,0 +1,169 @@
+import React, { useState, useRef, useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { useCreateApiToken } from '../../../api/apiTokens';
+import type { CreateTokenResponse } from '../../../types';
+import TokenDisplay from './TokenDisplay';
+
+interface CreateTokenModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const CreateTokenModal: React.FC<CreateTokenModalProps> = ({ isOpen, onClose }) => {
+  const [tokenName, setTokenName] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [createdToken, setCreatedToken] = useState<CreateTokenResponse | null>(null);
+  const [error, setError] = useState<string>('');
+  const createTokenMutation = useCreateApiToken();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus on mount for accessibility
+  useEffect(() => {
+    if (isOpen && !showToken) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen, showToken]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    // Validate input
+    if (!tokenName.trim()) {
+      setError('Token name is required');
+      return;
+    }
+
+    if (tokenName.length > 50) {
+      setError('Token name must be 50 characters or less');
+      return;
+    }
+
+    // Create token
+    createTokenMutation.mutate(tokenName, {
+      onSuccess: (token) => {
+        setCreatedToken(token);
+        setShowToken(true);
+        toast.success('API token created successfully');
+      },
+      onError: (error: unknown) => {
+        const message = error && typeof error === 'object' && 'message' in error
+          ? (error as { message: string }).message
+          : 'Failed to create token';
+        setError(message);
+        toast.error(message);
+      },
+    });
+  };
+
+  const handleDone = () => {
+    setTokenName('');
+    setShowToken(false);
+    setCreatedToken(null);
+    setError('');
+    onClose();
+  };
+
+  const handleClose = () => {
+    if (!showToken) {
+      handleDone();
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-md w-full max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white">
+            {showToken ? 'Token Created' : 'Create API Token'}
+          </h2>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 transition"
+            aria-label="Close modal"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">
+          {showToken && createdToken ? (
+            <TokenDisplay token={createdToken} onDone={handleDone} />
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Description */}
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Create a new personal API token to authenticate programmatically with the Klask API.
+              </p>
+
+              {/* Token Name Input */}
+              <div>
+                <label htmlFor="token-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Token Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  ref={inputRef}
+                  id="token-name"
+                  type="text"
+                  value={tokenName}
+                  onChange={(e) => {
+                    setTokenName(e.target.value);
+                    setError('');
+                  }}
+                  placeholder="e.g., Development, Production, CI/CD"
+                  maxLength={50}
+                  className={`w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition bg-white dark:bg-gray-900 text-gray-900 dark:text-white ${
+                    error ? 'border-red-500 dark:border-red-500' : 'border-gray-300 dark:border-gray-600'
+                  }`}
+                  disabled={createTokenMutation.isPending}
+                />
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  {tokenName.length}/50 characters
+                </p>
+              </div>
+
+              {/* Error Message */}
+              {error && (
+                <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+                  <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
+                </div>
+              )}
+
+              {/* Generate Button */}
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => handleClose()}
+                  className="px-6 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition font-medium"
+                  disabled={createTokenMutation.isPending}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={!tokenName.trim() || createTokenMutation.isPending}
+                  className="px-6 py-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 text-white rounded-lg disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition font-medium flex items-center gap-2"
+                >
+                  {createTokenMutation.isPending && (
+                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  )}
+                  {createTokenMutation.isPending ? 'Generating...' : 'Generate Token'}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CreateTokenModal;

--- a/klask-react/src/features/auth/tokens/TokenDisplay.tsx
+++ b/klask-react/src/features/auth/tokens/TokenDisplay.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import type { CreateTokenResponse } from '../../../types';
+
+interface TokenDisplayProps {
+  token: CreateTokenResponse;
+  onDone: () => void;
+}
+
+const TokenDisplay: React.FC<TokenDisplayProps> = ({ token, onDone }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(token.token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      console.error('Failed to copy token');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Success Message */}
+      <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
+        <div className="flex items-start gap-3">
+          <svg className="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+          </svg>
+          <div>
+            <h3 className="font-medium text-green-900 dark:text-green-300">Token Created Successfully</h3>
+            <p className="text-sm text-green-700 dark:text-green-400 mt-1">
+              Your API token has been generated. Copy it now and store it safely.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Token Display */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Your API Token
+        </label>
+        <div className="relative">
+          <div className="bg-gray-900 dark:bg-gray-950 rounded-lg p-4 font-mono text-sm text-green-400 break-all overflow-x-auto">
+            {token.token}
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="absolute top-3 right-3 px-3 py-1 bg-gray-700 hover:bg-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 text-white text-xs font-medium rounded transition"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+      </div>
+
+      {/* Token Prefix for Verification */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Token Prefix (for verification)
+        </label>
+        <div className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+          <code className="text-gray-900 dark:text-gray-300 font-mono text-sm">{token.token_prefix}...</code>
+        </div>
+      </div>
+
+      {/* Warning Box */}
+      <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+        <div className="flex items-start gap-3">
+          <svg className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+          </svg>
+          <div>
+            <h3 className="font-medium text-yellow-900 dark:text-yellow-300">Keep this token safe</h3>
+            <p className="text-sm text-yellow-700 dark:text-yellow-400 mt-1">
+              Do not commit this token to git or share it with others. Anyone with this token can access the API using your account.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Done Button */}
+      <div className="flex justify-end">
+        <button
+          onClick={onDone}
+          className="px-6 py-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 text-white rounded-lg transition font-medium"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TokenDisplay;

--- a/klask-react/src/features/auth/tokens/TokensList.tsx
+++ b/klask-react/src/features/auth/tokens/TokensList.tsx
@@ -1,0 +1,254 @@
+import React, { useState } from 'react';
+import toast from 'react-hot-toast';
+import { useRevokeApiToken, useApiTokens } from '../../../api/apiTokens';
+
+interface RevokeConfirmState {
+  tokenId: string | null;
+  tokenName: string | null;
+}
+
+const TokensList: React.FC = () => {
+  const { data: tokens, isLoading, error } = useApiTokens();
+  const revokeTokenMutation = useRevokeApiToken();
+  const [revokeConfirm, setRevokeConfirm] = useState<RevokeConfirmState>({ tokenId: null, tokenName: null });
+
+  const handleRevokeClick = (tokenId: string, tokenName: string) => {
+    setRevokeConfirm({ tokenId, tokenName });
+  };
+
+  const handleConfirmRevoke = () => {
+    if (!revokeConfirm.tokenId) return;
+
+    revokeTokenMutation.mutate(revokeConfirm.tokenId, {
+      onSuccess: () => {
+        toast.success(`Token "${revokeConfirm.tokenName}" revoked successfully`);
+        setRevokeConfirm({ tokenId: null, tokenName: null });
+      },
+      onError: (error: unknown) => {
+        const message = error && typeof error === 'object' && 'message' in error
+          ? (error as { message: string }).message
+          : 'Failed to revoke token';
+        toast.error(message);
+      },
+    });
+  };
+
+  // Helper function to format relative time
+  const getRelativeTime = (dateString: string | null): string => {
+    if (!dateString) return 'Never';
+
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+
+    if (diffDays > 0) return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+    if (diffHours > 0) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+    if (diffMinutes > 0) return `${diffMinutes} minute${diffMinutes > 1 ? 's' : ''} ago`;
+    return 'Just now';
+  };
+
+  // Helper function to format date for tooltip
+  const formatDate = (dateString: string): string => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="bg-gray-200 dark:bg-gray-700 rounded-lg h-16 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6 text-center">
+        <p className="text-red-700 dark:text-red-400">Failed to load API tokens</p>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (!tokens || tokens.length === 0) {
+    return (
+      <div className="bg-gray-50 dark:bg-gray-900/50 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-8 text-center">
+        <svg className="w-12 h-12 text-gray-400 dark:text-gray-500 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+        </svg>
+        <p className="text-gray-700 dark:text-gray-400 font-medium">No API tokens yet</p>
+        <p className="text-gray-600 dark:text-gray-500 text-sm mt-1">Create your first token to start using the API</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Tokens Table on larger screens */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Name</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Token Prefix</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Scope</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Created</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Last Used</th>
+              <th className="px-4 py-3 text-right text-sm font-semibold text-gray-700 dark:text-gray-300">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tokens.map((token) => (
+              <tr
+                key={token.id}
+                className="border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition"
+              >
+                <td className="px-4 py-3 text-sm text-gray-900 dark:text-white font-medium">
+                  {token.name}
+                  {token.revoked_at && (
+                    <span className="ml-2 inline-block px-2 py-1 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 text-xs rounded font-medium">
+                      Revoked
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 font-mono">
+                  {token.token_prefix}...
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                  {token.scope}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                  <div title={formatDate(token.created_at)}>
+                    {getRelativeTime(token.created_at)}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                  {token.last_used_at ? (
+                    <div title={formatDate(token.last_used_at)}>
+                      {getRelativeTime(token.last_used_at)}
+                    </div>
+                  ) : (
+                    <span className="text-gray-500 dark:text-gray-500">Never</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {!token.revoked_at && (
+                    <button
+                      onClick={() => handleRevokeClick(token.id, token.name)}
+                      className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 font-medium text-sm transition"
+                    >
+                      Revoke
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Tokens Cards on smaller screens */}
+      <div className="md:hidden space-y-4">
+        {tokens.map((token) => (
+          <div key={token.id} className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="font-medium text-gray-900 dark:text-white">{token.name}</h3>
+                {token.revoked_at && (
+                  <span className="inline-block mt-1 px-2 py-1 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 text-xs rounded font-medium">
+                    Revoked
+                  </span>
+                )}
+              </div>
+              {!token.revoked_at && (
+                <button
+                  onClick={() => handleRevokeClick(token.id, token.name)}
+                  className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 font-medium text-sm transition"
+                >
+                  Revoke
+                </button>
+              )}
+            </div>
+
+            <div className="space-y-2 text-sm">
+              <div>
+                <p className="text-gray-600 dark:text-gray-400">Prefix:</p>
+                <p className="font-mono text-gray-900 dark:text-white">{token.token_prefix}...</p>
+              </div>
+
+              <div>
+                <p className="text-gray-600 dark:text-gray-400">Scope:</p>
+                <p className="text-gray-900 dark:text-white">{token.scope}</p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <p className="text-gray-600 dark:text-gray-400">Created:</p>
+                  <p className="text-gray-900 dark:text-white" title={formatDate(token.created_at)}>
+                    {getRelativeTime(token.created_at)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-gray-600 dark:text-gray-400">Last Used:</p>
+                  <p className="text-gray-900 dark:text-white">
+                    {token.last_used_at ? (
+                      <span title={formatDate(token.last_used_at)}>
+                        {getRelativeTime(token.last_used_at)}
+                      </span>
+                    ) : (
+                      <span className="text-gray-500 dark:text-gray-500">Never</span>
+                    )}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Revoke Confirmation Dialog */}
+      {revokeConfirm.tokenId && (
+        <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center p-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-sm w-full">
+            <div className="p-6 space-y-6">
+              <div>
+                <h3 className="text-lg font-bold text-gray-900 dark:text-white">Revoke Token?</h3>
+                <p className="text-gray-600 dark:text-gray-400 mt-2">
+                  Are you sure you want to revoke the token "<span className="font-medium">{revokeConfirm.tokenName}</span>"? This action cannot be undone.
+                </p>
+              </div>
+
+              <div className="flex gap-3 justify-end">
+                <button
+                  onClick={() => setRevokeConfirm({ tokenId: null, tokenName: null })}
+                  className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition font-medium"
+                  disabled={revokeTokenMutation.isPending}
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleConfirmRevoke}
+                  disabled={revokeTokenMutation.isPending}
+                  className="px-4 py-2 bg-red-600 hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600 text-white rounded-lg disabled:bg-gray-400 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition font-medium flex items-center gap-2"
+                >
+                  {revokeTokenMutation.isPending && (
+                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  )}
+                  {revokeTokenMutation.isPending ? 'Revoking...' : 'Revoke Token'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TokensList;

--- a/klask-react/src/features/auth/tokens/TokensList.tsx
+++ b/klask-react/src/features/auth/tokens/TokensList.tsx
@@ -111,7 +111,7 @@ const TokensList: React.FC = () => {
               >
                 <td className="px-4 py-3 text-sm text-gray-900 dark:text-white font-medium">
                   {token.name}
-                  {token.revoked_at && (
+                  {!token.active && (
                     <span className="ml-2 inline-block px-2 py-1 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 text-xs rounded font-medium">
                       Revoked
                     </span>
@@ -138,7 +138,7 @@ const TokensList: React.FC = () => {
                   )}
                 </td>
                 <td className="px-4 py-3 text-right">
-                  {!token.revoked_at && (
+                  {!!token.active && (
                     <button
                       onClick={() => handleRevokeClick(token.id, token.name)}
                       className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 font-medium text-sm transition"
@@ -160,13 +160,13 @@ const TokensList: React.FC = () => {
             <div className="flex items-start justify-between gap-2">
               <div>
                 <h3 className="font-medium text-gray-900 dark:text-white">{token.name}</h3>
-                {token.revoked_at && (
+                {!token.active && (
                   <span className="inline-block mt-1 px-2 py-1 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 text-xs rounded font-medium">
                     Revoked
                   </span>
                 )}
               </div>
-              {!token.revoked_at && (
+              {!!token.active && (
                 <button
                   onClick={() => handleRevokeClick(token.id, token.name)}
                   className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 font-medium text-sm transition"

--- a/klask-react/src/features/auth/tokens/__tests__/TokenDisplay.test.tsx
+++ b/klask-react/src/features/auth/tokens/__tests__/TokenDisplay.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TokenDisplay from '../TokenDisplay';
+import type { CreateTokenResponse } from '../../../../types';
+
+describe('TokenDisplay', () => {
+  const mockToken: CreateTokenResponse = {
+    id: '1',
+    token: 'klask_pat_test123456789abcdefgh',
+    token_prefix: 'klask_pat_test123',
+    name: 'Test Token',
+    created_at: '2026-06-15T00:00:00Z',
+  };
+
+  const mockOnDone = vi.fn();
+
+  it('should render token display section', () => {
+    render(<TokenDisplay token={mockToken} onDone={mockOnDone} />);
+
+    expect(screen.getByText('Token Created Successfully')).toBeInTheDocument();
+    expect(screen.getByText('Your API Token')).toBeInTheDocument();
+    expect(screen.getByText(/Keep this token safe/)).toBeInTheDocument();
+  });
+
+  it('should display the token in a code block', () => {
+    render(<TokenDisplay token={mockToken} onDone={mockOnDone} />);
+
+    expect(screen.getByText(mockToken.token)).toBeInTheDocument();
+  });
+
+  it('should display the token prefix', () => {
+    render(<TokenDisplay token={mockToken} onDone={mockOnDone} />);
+
+    expect(screen.getByText(`${mockToken.token_prefix}...`)).toBeInTheDocument();
+  });
+
+  it('should have a copy button', () => {
+    render(<TokenDisplay token={mockToken} onDone={mockOnDone} />);
+
+    const copyButton = screen.getByRole('button', { name: /Copy/i });
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it('should call onDone when Done button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TokenDisplay token={mockToken} onDone={mockOnDone} />);
+
+    const doneButton = screen.getByRole('button', { name: /Done/i });
+    await user.click(doneButton);
+
+    expect(mockOnDone).toHaveBeenCalled();
+  });
+
+  it('should display warning about token safety', () => {
+    render(<TokenDisplay token={mockToken} onDone={mockOnDone} />);
+
+    expect(screen.getByText(/Do not commit this token to git/i)).toBeInTheDocument();
+  });
+});

--- a/klask-react/src/features/auth/tokens/index.ts
+++ b/klask-react/src/features/auth/tokens/index.ts
@@ -1,0 +1,4 @@
+export { default as ApiTokensPage } from './ApiTokensPage';
+export { default as CreateTokenModal } from './CreateTokenModal';
+export { default as TokensList } from './TokensList';
+export { default as TokenDisplay } from './TokenDisplay';

--- a/klask-react/src/hooks/useSearch.ts
+++ b/klask-react/src/hooks/useSearch.ts
@@ -25,6 +25,7 @@ const fetchWithAuth = async (url: string, options: RequestInit = {}) => {
   return fetch(fullUrl, {
     ...options,
     headers,
+    credentials: 'include', // Send HttpOnly auth cookie
   });
 };
 
@@ -54,7 +55,7 @@ export const useSearch = (
     retry: (failureCount, error) => {
       // Don't retry on 4xx errors (client errors)
       if (error && typeof error === 'object' && 'status' in error) {
-        const status = (error as any).status;
+        const status = (error as Record<string, unknown>).status as number;
         if (status >= 400 && status < 500) {
           return false;
         }
@@ -96,7 +97,7 @@ export const useInfiniteSearch = (
     initialPageParam: 0,
     retry: (failureCount, error) => {
       if (error && typeof error === 'object' && 'status' in error) {
-        const status = (error as any).status;
+        const status = (error as Record<string, unknown>).status as number;
         if (status >= 400 && status < 500) {
           return false;
         }
@@ -144,7 +145,6 @@ export const useMultiSelectSearch = (
   } = options;
 
   const pageSize = 20;
-  const offset = (currentPage - 1) * pageSize;
 
   return useQuery({
     queryKey: ['search', 'multiselect', query, filters, currentPage, fuzzySearch, regexSearch, regexFlags, caseSensitive],
@@ -218,7 +218,7 @@ export const useMultiSelectSearch = (
     placeholderData: keepPreviousData,
     retry: (failureCount, error) => {
       if (error && typeof error === 'object' && 'status' in error) {
-        const status = (error as any).status;
+        const status = (error as Record<string, unknown>).status as number;
         if (status >= 400 && status < 500) {
           return false;
         }
@@ -234,7 +234,7 @@ export const useAdvancedSearch = (
   filters: Record<string, string | undefined> = {},
   options: UseSearchOptions & { debounceMs?: number } = {}
 ) => {
-  const { debounceMs = 300, ...queryOptions } = options;
+  const { ...queryOptions } = options;
   
   // Create search query object
   const searchQuery: SearchQuery = {
@@ -301,7 +301,7 @@ export const usePaginatedSearch = (
     staleTime: options.staleTime || 30000,
     retry: (failureCount, error) => {
       if (error && typeof error === 'object' && 'status' in error) {
-        const status = (error as any).status;
+        const status = (error as Record<string, unknown>).status as number;
         if (status >= 400 && status < 500) {
           return false;
         }
@@ -316,7 +316,7 @@ export const useSearchSuggestions = (
   query: string,
   options: { enabled?: boolean; limit?: number } = {}
 ) => {
-  const { enabled = true, limit = 5 } = options;
+  const { enabled = true } = options;
 
   return useQuery({
     queryKey: ['search', 'suggestions', query],
@@ -525,9 +525,6 @@ export const useFacetsWithFilters = (
     };
   }, [debouncedFilters]);
 
-  // Check if any filters are selected
-  const hasActiveFilters = Object.values(filterKey).some((arr) => arr.length > 0);
-
   return useQuery({
     // Include filter values and query in query key for automatic deduplication by React Query
     queryKey: ['search', 'facets', filterKey, query],
@@ -579,7 +576,7 @@ export const useFacetsWithFilters = (
     retry: (failureCount, error) => {
       // Don't retry on 4xx errors (client errors)
       if (error && typeof error === 'object' && 'status' in error) {
-        const status = (error as any).status;
+        const status = (error as Record<string, unknown>).status as number;
         if (status >= 400 && status < 500) {
           return false;
         }

--- a/klask-react/src/lib/api.ts
+++ b/klask-react/src/lib/api.ts
@@ -475,6 +475,12 @@ class ApiClient {
     });
   }
 
+  async delete<T>(endpoint: string): Promise<T> {
+    return this.request<T>(endpoint, {
+      method: 'DELETE',
+    });
+  }
+
 }
 
 // Create and export the API client instance
@@ -542,6 +548,7 @@ export const api = {
   // Generic methods
   get: <T>(endpoint: string) => apiClient.get<T>(endpoint),
   post: <T>(endpoint: string, data?: unknown) => apiClient.post<T>(endpoint, data),
+  delete: <T>(endpoint: string) => apiClient.delete<T>(endpoint),
 
   // User Management
   getUsers: () => apiClient.getUsers(),

--- a/klask-react/src/stores/auth-store.ts
+++ b/klask-react/src/stores/auth-store.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { User } from '../types';
@@ -74,11 +75,10 @@ export const useAuthStore = create<AuthState>()(
         try {
           set({ isLoading: true });
           const user = await apiClient.auth.getProfile();
-          set({ user, isAuthenticated: true });
+          set({ user, isAuthenticated: true, isLoading: false });
         } catch (error) {
           console.error('Failed to refresh user:', error);
-          get().logout();
-        } finally {
+          await get().logout();
           set({ isLoading: false });
         }
       },
@@ -107,8 +107,8 @@ export const useAuthStore = create<AuthState>()(
       name: 'klask-auth',
       // Do NOT persist the token: the browser stores the HttpOnly cookie.
       // Only persist user info for instant UI rendering on load.
-      partialize: (state) => ({ 
-        user: state.user 
+      partialize: (state) => ({
+        user: state.user
       }),
       onRehydrateStorage: () => (state) => {
         if (state?.user) {
@@ -120,6 +120,17 @@ export const useAuthStore = create<AuthState>()(
     }
   )
 );
+
+// Hook to wait for rehydration to complete
+export const useIsHydrated = () => {
+  const [isHydrated, setIsHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  return isHydrated;
+};
 
 // Selectors for convenient access to auth state (use getState() — safe outside React components)
 export const authSelectors = {

--- a/klask-react/src/types/index.ts
+++ b/klask-react/src/types/index.ts
@@ -491,7 +491,7 @@ export interface FormState<T> {
 export interface NavItem {
   label: string;
   href: string;
-  icon?: React.ComponentType<any>;
+  icon?: React.ComponentType<Record<string, unknown>>;
   children?: NavItem[];
   requiresAuth?: boolean;
   requiredRole?: UserRole;
@@ -509,7 +509,7 @@ export type RequireField<T, K extends keyof T> = T & Required<Pick<T, K>>;
 // Event Types
 export interface SearchEvent {
   type: 'search' | 'filter' | 'sort' | 'paginate';
-  payload: any;
+  payload: Record<string, unknown>;
   timestamp: number;
 }
 

--- a/klask-react/src/types/index.ts
+++ b/klask-react/src/types/index.ts
@@ -619,3 +619,22 @@ export interface UseRepositoriesReturn {
   crawl: (id: string) => Promise<void>;
   refresh: () => void;
 }
+
+// API Tokens Types
+export interface ApiTokenInfo {
+  id: string;
+  name: string;
+  token_prefix: string;
+  scope: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface CreateTokenResponse {
+  id: string;
+  token: string;
+  token_prefix: string;
+  name: string;
+  created_at: string;
+}

--- a/klask-react/src/types/index.ts
+++ b/klask-react/src/types/index.ts
@@ -626,9 +626,10 @@ export interface ApiTokenInfo {
   name: string;
   token_prefix: string;
   scope: string;
+  active: boolean;
   created_at: string;
   last_used_at: string | null;
-  revoked_at: string | null;
+  expires_at: string | null;
 }
 
 export interface CreateTokenResponse {

--- a/klask-rs/.env.example
+++ b/klask-rs/.env.example
@@ -1,10 +1,13 @@
 # Database Configuration
-DATABASE_URL=postgres://klask_user:klask_password@postgres:5432/klask_dev
+DATABASE_URL=postgres://klask_user:klask_password@127.0.0.1:5432/klask_dev
 
 # Application Configuration
 RUST_LOG=info
 PORT=3000
 HOST=0.0.0.0
+
+# 10000 default
+SEARCH_MAX_RESULTS=1000
 
 # Security Configuration (IMPORTANT: Change this in production!)
 ENCRYPTION_KEY=your-super-secret-encryption-key-32-chars-minimum
@@ -18,7 +21,7 @@ JWT_EXPIRES_IN=24h
 ALLOW_REGISTRATION=true
 
 # Search Configuration
-SEARCH_INDEX_PATH=./index
+SEARCH_INDEX_DIR=./index
 
 # Crawler Configuration
 TEMP_DIR=./temp_crawl

--- a/klask-rs/migrations/20260615000000_add_api_tokens.sql
+++ b/klask-rs/migrations/20260615000000_add_api_tokens.sql
@@ -1,0 +1,35 @@
+-- Create api_tokens table for personal API token management
+-- Tokens follow format: klask_pat_<32 random chars>
+-- Tokens are hashed using Argon2 before storage (similar to passwords)
+
+CREATE TABLE api_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL UNIQUE,  -- Argon2 hash of the full token
+    token_prefix VARCHAR(12) NOT NULL,         -- "klask_pat_" + first 2 chars for display
+    name VARCHAR(255) NOT NULL,                -- User-friendly name (e.g., "GitHub Actions CI")
+    scope VARCHAR(50) NOT NULL DEFAULT 'read-only',  -- read-only, read-write, etc.
+    active BOOLEAN NOT NULL DEFAULT TRUE,      -- Soft delete (false = revoked)
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMP WITH TIME ZONE,     -- For audit trail
+    expires_at TIMESTAMP WITH TIME ZONE,       -- Optional expiration
+
+    -- Ensure non-empty fields
+    CHECK (length(trim(token_hash)) > 0),
+    CHECK (length(trim(token_prefix)) > 0),
+    CHECK (length(trim(name)) > 0),
+    CHECK (length(trim(scope)) > 0)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_api_tokens_user_id ON api_tokens(user_id);
+CREATE INDEX idx_api_tokens_user_id_active ON api_tokens(user_id, active);
+CREATE INDEX idx_api_tokens_user_id_created_at ON api_tokens(user_id, created_at DESC);
+CREATE INDEX idx_api_tokens_token_hash ON api_tokens(token_hash);  -- For quick lookup during auth
+
+-- Comment documenting the token format and security model
+COMMENT ON TABLE api_tokens IS 'Personal API tokens for programmatic access. Tokens are hashed using Argon2 before storage.';
+COMMENT ON COLUMN api_tokens.token_hash IS 'Argon2 hash of the full token (klask_pat_XXXXX). Never expose plaintext after creation.';
+COMMENT ON COLUMN api_tokens.token_prefix IS 'Display-safe prefix of token for UI (e.g., "klask_pat_ab" from "klask_pat_ab12...").';
+COMMENT ON COLUMN api_tokens.scope IS 'Token scope/permissions. Currently: read-only. Future: read-write, write-only.';
+COMMENT ON COLUMN api_tokens.active IS 'Soft delete flag. false = token has been revoked.';

--- a/klask-rs/src/api/users.rs
+++ b/klask-rs/src/api/users.rs
@@ -325,7 +325,10 @@ async fn list_tokens(
             let token_infos: Vec<ApiTokenInfo> = tokens.into_iter().map(|t| t.into()).collect();
             Ok(Json(token_infos))
         }
-        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+        Err(e) => {
+            tracing::error!("Failed to list API tokens for user {}: {:?}", auth_user.user.id, e);
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
     }
 }
 
@@ -373,7 +376,10 @@ async fn create_token(
         .await
     {
         Ok(token) => token,
-        Err(_) => return Err(AuthError::InvalidInput("Failed to create token".to_string())),
+        Err(e) => {
+            tracing::error!("Failed to create API token for user {}: {:?}", auth_user.user.id, e);
+            return Err(AuthError::InvalidInput("Failed to create token".to_string()));
+        }
     };
 
     Ok(Json(CreateApiTokenResponse {
@@ -405,10 +411,23 @@ async fn revoke_token(
             // Revoke the token
             match api_token_repo.revoke_token(token_id).await {
                 Ok(()) => Ok(StatusCode::NO_CONTENT),
-                Err(_) => Err(AuthError::InvalidInput("Failed to revoke token".to_string())),
+                Err(e) => {
+                    tracing::error!("Failed to revoke API token {}: {:?}", token_id, e);
+                    Err(AuthError::InvalidInput("Failed to revoke token".to_string()))
+                }
             }
         }
-        Ok(None) => Err(AuthError::InvalidInput("Token not found".to_string())),
-        Err(_) => Err(AuthError::InvalidInput("Database error".to_string())),
+        Ok(None) => {
+            tracing::warn!(
+                "User {} attempted to revoke non-existent token {}",
+                auth_user.user.id,
+                token_id
+            );
+            Err(AuthError::InvalidInput("Token not found".to_string()))
+        }
+        Err(e) => {
+            tracing::error!("Database error while fetching token {}: {:?}", token_id, e);
+            Err(AuthError::InvalidInput("Database error".to_string()))
+        }
     }
 }

--- a/klask-rs/src/api/users.rs
+++ b/klask-rs/src/api/users.rs
@@ -1,8 +1,11 @@
 use crate::api::auth::validate_password_strength;
 use crate::auth::AuthError;
-use crate::auth::extractors::{AdminUser, AppState};
-use crate::models::{User, UserRole};
-use crate::repositories::{UserRepository, user_repository::UserStats};
+use crate::auth::extractors::{AdminUser, AppState, AuthenticatedUser};
+use crate::models::{
+    ApiTokenInfo, CreateApiTokenRequest, CreateApiTokenResponse, User, UserRole, extract_token_prefix,
+    generate_api_token,
+};
+use crate::repositories::{ApiTokenRepository, UserRepository, user_repository::UserStats};
 use crate::utils::password::hash_password;
 use anyhow::Result;
 use axum::{
@@ -10,7 +13,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
-    routing::{get, put},
+    routing::{delete, get, put},
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -78,7 +81,10 @@ pub async fn create_router() -> Result<Router<AppState>> {
         .route("/{id}", get(get_user).put(update_user).delete(delete_user))
         .route("/{id}/role", put(update_user_role))
         .route("/{id}/status", put(update_user_status))
-        .route("/stats", get(get_user_stats));
+        .route("/stats", get(get_user_stats))
+        // API token routes (authenticated users only)
+        .route("/tokens", get(list_tokens).post(create_token))
+        .route("/tokens/{id}", delete(revoke_token));
 
     Ok(router)
 }
@@ -302,5 +308,107 @@ async fn get_user_stats(
     match user_repository.get_user_stats().await {
         Ok(stats) => Ok(Json(stats)),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+// API Token Management Endpoints
+
+/// List all API tokens for the authenticated user
+async fn list_tokens(
+    State(app_state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<Json<Vec<ApiTokenInfo>>, StatusCode> {
+    let api_token_repo = ApiTokenRepository::new(app_state.database.pool().clone());
+
+    match api_token_repo.list_tokens(auth_user.user.id).await {
+        Ok(tokens) => {
+            let token_infos: Vec<ApiTokenInfo> = tokens.into_iter().map(|t| t.into()).collect();
+            Ok(Json(token_infos))
+        }
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+/// Create a new API token for the authenticated user
+async fn create_token(
+    State(app_state): State<AppState>,
+    auth_user: AuthenticatedUser,
+    Json(payload): Json<CreateApiTokenRequest>,
+) -> Result<Json<CreateApiTokenResponse>, AuthError> {
+    // Validate token name
+    if payload.name.trim().is_empty() {
+        return Err(AuthError::InvalidInput("Token name cannot be empty".to_string()));
+    }
+
+    if payload.name.len() > 255 {
+        return Err(AuthError::InvalidInput(
+            "Token name must be 255 characters or less".to_string(),
+        ));
+    }
+
+    // Generate the plaintext token
+    let plaintext_token = generate_api_token();
+
+    // Hash the token using the same method as passwords
+    let token_hash = match hash_password(&plaintext_token) {
+        Ok(hash) => hash,
+        Err(_) => return Err(AuthError::InvalidInput("Failed to hash token".to_string())),
+    };
+
+    // Extract the prefix for display
+    let token_prefix = extract_token_prefix(&plaintext_token);
+
+    // Create the token in the database
+    let api_token_repo = ApiTokenRepository::new(app_state.database.pool().clone());
+
+    let created_token = match api_token_repo
+        .create_token(
+            auth_user.user.id,
+            &payload.name,
+            "read-only",
+            &token_hash,
+            &token_prefix,
+            payload.expires_in_days,
+        )
+        .await
+    {
+        Ok(token) => token,
+        Err(_) => return Err(AuthError::InvalidInput("Failed to create token".to_string())),
+    };
+
+    Ok(Json(CreateApiTokenResponse {
+        id: created_token.id,
+        token: plaintext_token, // Show plaintext only once
+        token_prefix: created_token.token_prefix,
+        name: created_token.name,
+        scope: created_token.scope,
+        created_at: created_token.created_at,
+    }))
+}
+
+/// Revoke an API token (soft delete)
+async fn revoke_token(
+    State(app_state): State<AppState>,
+    Path(token_id): Path<Uuid>,
+    auth_user: AuthenticatedUser,
+) -> Result<StatusCode, AuthError> {
+    let api_token_repo = ApiTokenRepository::new(app_state.database.pool().clone());
+
+    // Get the token to verify ownership
+    match api_token_repo.get_token(token_id).await {
+        Ok(Some(token)) => {
+            // Check ownership: user can only revoke their own tokens
+            if token.user_id != auth_user.user.id {
+                return Err(AuthError::Forbidden("Cannot revoke tokens of other users".to_string()));
+            }
+
+            // Revoke the token
+            match api_token_repo.revoke_token(token_id).await {
+                Ok(()) => Ok(StatusCode::NO_CONTENT),
+                Err(_) => Err(AuthError::InvalidInput("Failed to revoke token".to_string())),
+            }
+        }
+        Ok(None) => Err(AuthError::InvalidInput("Token not found".to_string())),
+        Err(_) => Err(AuthError::InvalidInput("Database error".to_string())),
     }
 }

--- a/klask-rs/src/api/users.rs
+++ b/klask-rs/src/api/users.rs
@@ -3,7 +3,7 @@ use crate::auth::AuthError;
 use crate::auth::extractors::{AdminUser, AppState, AuthenticatedUser};
 use crate::models::{
     ApiTokenInfo, CreateApiTokenRequest, CreateApiTokenResponse, User, UserRole, extract_token_prefix,
-    generate_api_token,
+    generate_api_token, hash_api_token,
 };
 use crate::repositories::{ApiTokenRepository, UserRepository, user_repository::UserStats};
 use crate::utils::password::hash_password;
@@ -78,13 +78,14 @@ impl From<User> for UserResponse {
 pub async fn create_router() -> Result<Router<AppState>> {
     let router = Router::new()
         .route("/", get(list_users).post(create_user))
+        // Specific routes before generic {id} routes
+        .route("/stats", get(get_user_stats))
+        .route("/tokens", get(list_tokens).post(create_token))
+        .route("/tokens/{id}", delete(revoke_token))
+        // Generic {id} routes last
         .route("/{id}", get(get_user).put(update_user).delete(delete_user))
         .route("/{id}/role", put(update_user_role))
-        .route("/{id}/status", put(update_user_status))
-        .route("/stats", get(get_user_stats))
-        // API token routes (authenticated users only)
-        .route("/tokens", get(list_tokens).post(create_token))
-        .route("/tokens/{id}", delete(revoke_token));
+        .route("/{id}/status", put(update_user_status));
 
     Ok(router)
 }
@@ -352,11 +353,8 @@ async fn create_token(
     // Generate the plaintext token
     let plaintext_token = generate_api_token();
 
-    // Hash the token using the same method as passwords
-    let token_hash = match hash_password(&plaintext_token) {
-        Ok(hash) => hash,
-        Err(_) => return Err(AuthError::InvalidInput("Failed to hash token".to_string())),
-    };
+    // Hash the token using SHA-256 (fast, suitable for short-lived revocable tokens)
+    let token_hash = hash_api_token(&plaintext_token);
 
     // Extract the prefix for display
     let token_prefix = extract_token_prefix(&plaintext_token);

--- a/klask-rs/src/auth/extractors.rs
+++ b/klask-rs/src/auth/extractors.rs
@@ -1,10 +1,12 @@
 use crate::auth::{claims::TokenClaims, errors::AuthError, jwt::JwtService};
 use crate::database::Database;
 use crate::models::user::{User, UserRole};
+use crate::repositories::api_token_repository::ApiTokenRepository;
 use crate::repositories::user_repository::UserRepository;
 use crate::services::{encryption::EncryptionService, progress::ProgressTracker};
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
+use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -125,6 +127,12 @@ fn extract_token_from_cookie(cookies: &str, name: &str) -> Option<String> {
 async fn extract_authenticated_user(state: &AppState, token: &str) -> Result<AuthenticatedUser, AuthError> {
     trace!("Extracting AuthenticatedUser from request");
 
+    // Check if this is an API token (format: klask_pat_XXXXX)
+    if token.starts_with("klask_pat_") {
+        return extract_authenticated_user_from_api_token(state, token).await;
+    }
+
+    // Otherwise, treat as JWT
     // Decode and validate token
     let claims = state.jwt_service.decode_token(token).map_err(|e| {
         error!("Failed to decode token: {:?}", e);
@@ -167,6 +175,97 @@ async fn extract_authenticated_user(state: &AppState, token: &str) -> Result<Aut
     }
 
     trace!("AuthenticatedUser extracted successfully: {}", user.username);
+    Ok(AuthenticatedUser { user, claims })
+}
+
+/// Extract and validate an authenticated user from a personal API token
+/// API tokens follow the format: klask_pat_XXXXX (42 characters total)
+async fn extract_authenticated_user_from_api_token(
+    state: &AppState,
+    token: &str,
+) -> Result<AuthenticatedUser, AuthError> {
+    trace!("Extracting AuthenticatedUser from API token");
+
+    // Validate token format
+    if !token.starts_with("klask_pat_") || token.len() != 42 {
+        warn!("Invalid API token format");
+        return Err(AuthError::InvalidToken("Invalid token format".to_string()));
+    }
+
+    // Fetch the token repository
+    let api_token_repo = ApiTokenRepository::new(state.database.pool().clone());
+
+    // Find token by plaintext (repository handles Argon2 verification)
+    let api_token = api_token_repo
+        .find_by_token(token)
+        .await
+        .map_err(|e| {
+            error!("Database error while looking up API token: {:?}", e);
+            AuthError::DatabaseError(e.to_string())
+        })?
+        .ok_or_else(|| {
+            trace!("API token not found or invalid");
+            AuthError::InvalidToken("Token not found or invalid".to_string())
+        })?;
+
+    // Check if token is active (not revoked)
+    if !api_token.active {
+        warn!("Revoked API token used for user {}", api_token.user_id);
+        return Err(AuthError::InvalidToken("Token has been revoked".to_string()));
+    }
+
+    // Check if token is expired
+    if let Some(expires_at) = api_token.expires_at
+        && Utc::now() > expires_at
+    {
+        warn!("Expired API token used for user {}", api_token.user_id);
+        return Err(AuthError::TokenExpired);
+    }
+
+    // Fetch user from database
+    let user_repo = UserRepository::new(state.database.pool().clone());
+    let user = user_repo
+        .get_user(api_token.user_id)
+        .await
+        .map_err(|e| {
+            error!("Database error while fetching user {}: {:?}", api_token.user_id, e);
+            AuthError::DatabaseError(e.to_string())
+        })?
+        .ok_or_else(|| {
+            warn!("User not found for API token");
+            AuthError::UserNotFound
+        })?;
+
+    // Verify user is active
+    if !user.active {
+        warn!(
+            "Inactive user attempted to authenticate with API token: {}",
+            user.username
+        );
+        return Err(AuthError::UserInactive);
+    }
+
+    trace!("API token validated successfully for user: {}", user.username);
+
+    // Create synthetic claims for API tokens
+    // API tokens don't expire based on JWT expiration; they use api_tokens.expires_at
+    let claims = TokenClaims::new(
+        user.id,
+        user.username.clone(),
+        "api-token".to_string(),
+        chrono::Duration::days(365 * 10), // Long expiration since we validate separately
+    );
+
+    // Update last_used_at in background (non-blocking)
+    let token_id = api_token.id;
+    let pool = state.database.pool().clone();
+    tokio::spawn(async move {
+        let repo = ApiTokenRepository::new(pool);
+        if let Err(e) = repo.update_last_used(token_id).await {
+            error!("Failed to update last_used_at for API token: {:?}", e);
+        }
+    });
+
     Ok(AuthenticatedUser { user, claims })
 }
 

--- a/klask-rs/src/lib.rs
+++ b/klask-rs/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod auth;
 pub mod config;
 pub mod database;
+pub mod mcp;
 pub mod models;
 pub mod repositories;
 pub mod services;

--- a/klask-rs/src/main.rs
+++ b/klask-rs/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod auth;
 mod config;
 mod database;
+mod mcp;
 mod models;
 mod repositories;
 mod services;
@@ -296,6 +297,7 @@ async fn create_app(app_state: AppState, config: AppConfig) -> Result<Router> {
             }),
         )
         .nest("/api", api::create_router().await?)
+        .merge(mcp::create_router())
         .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(app_state);

--- a/klask-rs/src/mcp/mod.rs
+++ b/klask-rs/src/mcp/mod.rs
@@ -1,0 +1,102 @@
+//! MCP (Model Context Protocol) server exposing Klask's code search to AI agents.
+//!
+//! Implements a stateless, tools-only MCP server over the Streamable HTTP
+//! transport: a single `POST /mcp` endpoint answering each JSON-RPC message
+//! with a plain JSON response (no SSE streams, no sessions). Authentication
+//! reuses the standard `Authorization: Bearer <token>` flow.
+//!
+//! See `docs/MCP_SERVER_PLAN.md` for the design rationale.
+
+pub mod protocol;
+pub mod tools;
+
+use crate::auth::extractors::{AppState, AuthenticatedUser};
+use axum::{
+    Router,
+    extract::State,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use protocol::{INVALID_PARAMS, INVALID_REQUEST, JsonRpcRequest, JsonRpcResponse, METHOD_NOT_FOUND, PARSE_ERROR};
+use serde_json::{Value, json};
+
+/// Router exposing the MCP endpoint at `/mcp`.
+pub fn create_router() -> Router<AppState> {
+    Router::new().route("/mcp", post(handle_post).fallback(handle_unsupported_method))
+}
+
+/// Non-POST methods: this stateless server has no server-initiated streams (GET)
+/// and no sessions to terminate (DELETE).
+async fn handle_unsupported_method() -> Response {
+    (
+        StatusCode::METHOD_NOT_ALLOWED,
+        [(header::ALLOW, "POST")],
+        "MCP endpoint only accepts POST",
+    )
+        .into_response()
+}
+
+async fn handle_post(_auth: AuthenticatedUser, State(state): State<AppState>, body: String) -> Response {
+    let request: JsonRpcRequest = match serde_json::from_str(&body) {
+        Ok(request) => request,
+        Err(e) => {
+            return json_response(JsonRpcResponse::error(
+                Value::Null,
+                PARSE_ERROR,
+                format!("Parse error: {e}"),
+            ));
+        }
+    };
+
+    if request.jsonrpc != protocol::JSONRPC_VERSION {
+        let id = request.id.unwrap_or(Value::Null);
+        return json_response(JsonRpcResponse::error(
+            id,
+            INVALID_REQUEST,
+            "Unsupported JSON-RPC version",
+        ));
+    }
+
+    // Notifications (no id) must not receive a JSON-RPC response
+    if request.is_notification() {
+        return StatusCode::ACCEPTED.into_response();
+    }
+
+    let id = request.id.clone().unwrap_or(Value::Null);
+    tracing::debug!("MCP request: method={}", request.method);
+
+    let response = match request.method.as_str() {
+        "initialize" => {
+            let requested_version = request.params.get("protocolVersion").and_then(Value::as_str);
+            JsonRpcResponse::success(id, protocol::initialize_result(requested_version))
+        }
+        "ping" => JsonRpcResponse::success(id, json!({})),
+        "tools/list" => JsonRpcResponse::success(id, json!({ "tools": tools::tool_definitions() })),
+        "tools/call" => handle_tools_call(&state, id, &request.params).await,
+        method => JsonRpcResponse::error(id, METHOD_NOT_FOUND, format!("Method not found: {method}")),
+    };
+
+    json_response(response)
+}
+
+async fn handle_tools_call(state: &AppState, id: Value, params: &Value) -> JsonRpcResponse {
+    let Some(name) = params.get("name").and_then(Value::as_str) else {
+        return JsonRpcResponse::error(id, INVALID_PARAMS, "Missing tool 'name' in params");
+    };
+
+    let default_arguments = Value::Null;
+    let arguments = params.get("arguments").unwrap_or(&default_arguments);
+
+    match tools::call_tool(state, name, arguments).await {
+        Ok(result) => JsonRpcResponse::success(id, result),
+        Err(tools::ToolCallError::UnknownTool(tool)) => {
+            JsonRpcResponse::error(id, INVALID_PARAMS, format!("Unknown tool: {tool}"))
+        }
+        Err(tools::ToolCallError::InvalidParams(message)) => JsonRpcResponse::error(id, INVALID_PARAMS, message),
+    }
+}
+
+fn json_response(response: JsonRpcResponse) -> Response {
+    (StatusCode::OK, axum::Json(response)).into_response()
+}

--- a/klask-rs/src/mcp/mod.rs
+++ b/klask-rs/src/mcp/mod.rs
@@ -38,8 +38,10 @@ async fn handle_unsupported_method() -> Response {
 }
 
 async fn handle_post(_auth: AuthenticatedUser, State(state): State<AppState>, body: String) -> Response {
-    let request: JsonRpcRequest = match serde_json::from_str(&body) {
-        Ok(request) => request,
+    // -32700 is reserved for malformed JSON; a well-formed body that is not a
+    // valid Request object (missing method/jsonrpc, wrong types) is -32600.
+    let value: Value = match serde_json::from_str(&body) {
+        Ok(value) => value,
         Err(e) => {
             return json_response(JsonRpcResponse::error(
                 Value::Null,
@@ -49,8 +51,23 @@ async fn handle_post(_auth: AuthenticatedUser, State(state): State<AppState>, bo
         }
     };
 
+    let request: JsonRpcRequest = match serde::Deserialize::deserialize(&value) {
+        Ok(request) => request,
+        Err(e) => {
+            let id = value.get("id").cloned().unwrap_or(Value::Null);
+            return json_response(JsonRpcResponse::error(
+                id,
+                INVALID_REQUEST,
+                format!("Invalid request: {e}"),
+            ));
+        }
+    };
+
     if request.jsonrpc != protocol::JSONRPC_VERSION {
-        let id = request.id.unwrap_or(Value::Null);
+        // Never answer an id-less message, even an invalid one
+        let Some(id) = request.id.clone() else {
+            return StatusCode::ACCEPTED.into_response();
+        };
         return json_response(JsonRpcResponse::error(
             id,
             INVALID_REQUEST,

--- a/klask-rs/src/mcp/protocol.rs
+++ b/klask-rs/src/mcp/protocol.rs
@@ -1,0 +1,197 @@
+//! JSON-RPC 2.0 and MCP protocol types for the Klask MCP server.
+//!
+//! Implements the minimal protocol surface needed by a stateless, tools-only
+//! MCP server over Streamable HTTP: `initialize`, `notifications/initialized`,
+//! `tools/list`, `tools/call` and `ping`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub const JSONRPC_VERSION: &str = "2.0";
+
+/// Latest protocol revision this server implements.
+pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Older revisions we can serve as-is (the subset of the protocol used by a
+/// stateless tools-only server is identical across these revisions).
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26", "2024-11-05"];
+
+// JSON-RPC 2.0 error codes
+pub const PARSE_ERROR: i32 = -32700;
+pub const INVALID_REQUEST: i32 = -32600;
+pub const METHOD_NOT_FOUND: i32 = -32601;
+pub const INVALID_PARAMS: i32 = -32602;
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+    /// Absent for notifications.
+    #[serde(default)]
+    pub id: Option<Value>,
+}
+
+impl JsonRpcRequest {
+    /// A request without an id is a notification and must not receive a response.
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+    pub id: Value,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: Value, result: Value) -> Self {
+        Self { jsonrpc: JSONRPC_VERSION, result: Some(result), error: None, id }
+    }
+
+    pub fn error(id: Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION,
+            result: None,
+            error: Some(JsonRpcError { code, message: message.into(), data: None }),
+            id,
+        }
+    }
+}
+
+/// Negotiate the protocol version: echo the client's requested revision when we
+/// support it, otherwise answer with our latest revision (per MCP spec).
+pub fn negotiate_protocol_version(requested: Option<&str>) -> &'static str {
+    match requested {
+        Some(v) => SUPPORTED_PROTOCOL_VERSIONS.iter().find(|s| **s == v).copied().unwrap_or(MCP_PROTOCOL_VERSION),
+        None => MCP_PROTOCOL_VERSION,
+    }
+}
+
+/// Build the `initialize` result payload.
+pub fn initialize_result(requested_version: Option<&str>) -> Value {
+    json!({
+        "protocolVersion": negotiate_protocol_version(requested_version),
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": "klask",
+            "title": "Klask Code Search",
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        "instructions": "Klask indexes all the organization's Git repositories and branches. \
+            Use search_code to find code across every indexed repository, get_file to read a \
+            file found in search results (via its doc_address), list_repositories to see what \
+            is indexed, and get_search_facets to discover available projects, branches and \
+            file extensions before narrowing a search."
+    })
+}
+
+/// Build a `tools/call` result carrying a JSON payload as text content.
+pub fn tool_result(payload: &Value) -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": payload.to_string()
+        }],
+        "isError": false
+    })
+}
+
+/// Build a `tools/call` execution-error result (per MCP spec, tool failures are
+/// reported in-band with `isError: true`, not as JSON-RPC errors).
+pub fn tool_error(message: impl AsRef<str>) -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": message.as_ref()
+        }],
+        "isError": true
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_request_with_id() {
+        let req: JsonRpcRequest =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#).expect("valid request");
+        assert_eq!(req.method, "tools/list");
+        assert!(!req.is_notification());
+        assert_eq!(req.id, Some(json!(1)));
+    }
+
+    #[test]
+    fn test_parse_notification_without_id() {
+        let req: JsonRpcRequest =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#).expect("valid request");
+        assert!(req.is_notification());
+    }
+
+    #[test]
+    fn test_parse_request_with_string_id_and_params() {
+        let req: JsonRpcRequest = serde_json::from_str(
+            r#"{"jsonrpc":"2.0","method":"tools/call","id":"abc","params":{"name":"search_code"}}"#,
+        )
+        .expect("valid request");
+        assert_eq!(req.id, Some(json!("abc")));
+        assert_eq!(req.params["name"], "search_code");
+    }
+
+    #[test]
+    fn test_success_response_serialization() {
+        let resp = JsonRpcResponse::success(json!(1), json!({"ok": true}));
+        let serialized = serde_json::to_value(&resp).expect("serializable");
+        assert_eq!(serialized["jsonrpc"], "2.0");
+        assert_eq!(serialized["result"]["ok"], true);
+        assert!(serialized.get("error").is_none());
+    }
+
+    #[test]
+    fn test_error_response_serialization() {
+        let resp = JsonRpcResponse::error(json!(2), METHOD_NOT_FOUND, "Method not found");
+        let serialized = serde_json::to_value(&resp).expect("serializable");
+        assert_eq!(serialized["error"]["code"], METHOD_NOT_FOUND);
+        assert!(serialized.get("result").is_none());
+    }
+
+    #[test]
+    fn test_negotiate_protocol_version() {
+        assert_eq!(negotiate_protocol_version(Some("2025-03-26")), "2025-03-26");
+        assert_eq!(negotiate_protocol_version(Some("1999-01-01")), MCP_PROTOCOL_VERSION);
+        assert_eq!(negotiate_protocol_version(None), MCP_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn test_tool_result_wraps_payload_as_text() {
+        let result = tool_result(&json!({"total": 3}));
+        assert_eq!(result["isError"], false);
+        let text = result["content"][0]["text"].as_str().expect("text content");
+        let parsed: Value = serde_json::from_str(text).expect("payload is valid JSON");
+        assert_eq!(parsed["total"], 3);
+    }
+
+    #[test]
+    fn test_tool_error_sets_is_error() {
+        let result = tool_error("boom");
+        assert_eq!(result["isError"], true);
+        assert_eq!(result["content"][0]["text"], "boom");
+    }
+}

--- a/klask-rs/src/mcp/tools.rs
+++ b/klask-rs/src/mcp/tools.rs
@@ -54,7 +54,7 @@ pub fn tool_definitions() -> Value {
                         "description": "Search terms, a \"quoted phrase\", or a regex pattern when regex is true"
                     },
                     "repositories": string_array("Restrict to these repository names"),
-                    "projects": string_array("Restrict to these project names (GitLab/GitHub sub-projects)"),
+                    "projects": string_array("Restrict to these project names using full path (e.g., 'klask-dev/klask-dev'). Use get_search_facets to discover available projects."),
                     "versions": string_array("Restrict to these branches or tags (e.g. [\"main\"])"),
                     "extensions": string_array("Restrict to these file extensions, without dot (e.g. [\"rs\", \"ts\"])"),
                     "regex": {

--- a/klask-rs/src/mcp/tools.rs
+++ b/klask-rs/src/mcp/tools.rs
@@ -1,0 +1,518 @@
+//! MCP tool definitions and handlers.
+//!
+//! Tools are thin adapters over the existing services (`SearchService`,
+//! `RepositoryRepository`): protocol-level failures (unknown tool, invalid
+//! arguments) surface as JSON-RPC errors, while execution failures are
+//! reported in-band via `isError: true` results, per the MCP specification.
+
+use crate::auth::extractors::AppState;
+use crate::repositories::repository_repository::RepositoryRepository;
+use crate::services::SearchQuery;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// Maximum number of search results a single tool call can return.
+const MAX_SEARCH_LIMIT: u32 = 100;
+const DEFAULT_SEARCH_LIMIT: u32 = 20;
+
+/// Maximum number of lines returned by `get_file` in a single call.
+const MAX_FILE_LINES: usize = 2000;
+
+/// Protocol-level tool call failures (mapped to JSON-RPC errors by the caller).
+#[derive(Debug)]
+pub enum ToolCallError {
+    UnknownTool(String),
+    InvalidParams(String),
+}
+
+/// Tool definitions advertised by `tools/list`.
+pub fn tool_definitions() -> Value {
+    let string_array = |description: &str| {
+        json!({
+            "type": "array",
+            "items": { "type": "string" },
+            "description": description
+        })
+    };
+
+    json!([
+        {
+            "name": "search_code",
+            "description": "Full-text search across all indexed Git repositories and branches. \
+                Supports plain terms, exact phrases (in double quotes) and regular expressions. \
+                Returns matching files with a content snippet, the matching line number and a \
+                doc_address usable with the get_file tool.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search terms, a \"quoted phrase\", or a regex pattern when regex is true"
+                    },
+                    "repositories": string_array("Restrict to these repository names"),
+                    "projects": string_array("Restrict to these project names (GitLab/GitHub sub-projects)"),
+                    "versions": string_array("Restrict to these branches or tags (e.g. [\"main\"])"),
+                    "extensions": string_array("Restrict to these file extensions, without dot (e.g. [\"rs\", \"ts\"])"),
+                    "regex": {
+                        "type": "boolean",
+                        "description": "Treat query as a regular expression (default false)"
+                    },
+                    "case_sensitive": {
+                        "type": "boolean",
+                        "description": "Case-sensitive matching (default false)"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_SEARCH_LIMIT,
+                        "description": "Maximum results to return (default 20, max 100)"
+                    },
+                    "page": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Result page, 1-based (default 1)"
+                    }
+                },
+                "required": ["query"]
+            }
+        },
+        {
+            "name": "get_file",
+            "description": "Retrieve the content of an indexed file, identified by the doc_address \
+                (preferred, as returned by search_code) or by file_id. Large files are truncated; \
+                use start_line/end_line to read a specific range.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "doc_address": {
+                        "type": "string",
+                        "description": "Document address from search_code results (format \"segment:doc\")"
+                    },
+                    "file_id": {
+                        "type": "string",
+                        "description": "File UUID from search_code results (alternative to doc_address)"
+                    },
+                    "start_line": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "First line to return, 1-based inclusive (default 1)"
+                    },
+                    "end_line": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Last line to return, 1-based inclusive (default end of file)"
+                    }
+                }
+            }
+        },
+        {
+            "name": "list_repositories",
+            "description": "List the repositories indexed by Klask with their type (Git, GitLab, \
+                GitHub, FileSystem), URL and last crawl time.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        },
+        {
+            "name": "get_search_facets",
+            "description": "Discover what is searchable: returns the available repositories, \
+                projects, branches/tags and file extensions with their document counts, optionally \
+                narrowed by a query and/or filters. Useful to scope a search_code call.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Optional search query to narrow the facets"
+                    },
+                    "repositories": string_array("Restrict to these repository names"),
+                    "projects": string_array("Restrict to these project names"),
+                    "versions": string_array("Restrict to these branches or tags"),
+                    "extensions": string_array("Restrict to these file extensions, without dot")
+                }
+            }
+        }
+    ])
+}
+
+/// Dispatch a `tools/call` request to the matching tool handler.
+pub async fn call_tool(state: &AppState, name: &str, arguments: &Value) -> Result<Value, ToolCallError> {
+    match name {
+        "search_code" => search_code(state, arguments).await,
+        "get_file" => get_file(state, arguments).await,
+        "list_repositories" => list_repositories(state).await,
+        "get_search_facets" => get_search_facets(state, arguments).await,
+        other => Err(ToolCallError::UnknownTool(other.to_string())),
+    }
+}
+
+fn parse_args<T: serde::de::DeserializeOwned>(arguments: &Value) -> Result<T, ToolCallError> {
+    // tools/call without an "arguments" field is valid for tools with no required input
+    let value = if arguments.is_null() { json!({}) } else { arguments.clone() };
+    serde_json::from_value(value).map_err(|e| ToolCallError::InvalidParams(format!("Invalid tool arguments: {e}")))
+}
+
+/// Join an optional list filter into the comma-separated form expected by `SearchService`.
+fn join_filter(values: &Option<Vec<String>>) -> Option<String> {
+    values.as_ref().and_then(|v| {
+        let joined = v.iter().map(|s| s.trim()).filter(|s| !s.is_empty()).collect::<Vec<_>>().join(",");
+        if joined.is_empty() { None } else { Some(joined) }
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchCodeArgs {
+    query: String,
+    repositories: Option<Vec<String>>,
+    projects: Option<Vec<String>>,
+    versions: Option<Vec<String>>,
+    extensions: Option<Vec<String>>,
+    #[serde(default)]
+    regex: bool,
+    #[serde(default)]
+    case_sensitive: bool,
+    limit: Option<u32>,
+    page: Option<u32>,
+}
+
+async fn search_code(state: &AppState, arguments: &Value) -> Result<Value, ToolCallError> {
+    let args: SearchCodeArgs = parse_args(arguments)?;
+
+    if args.query.trim().is_empty() {
+        return Err(ToolCallError::InvalidParams("'query' must not be empty".to_string()));
+    }
+
+    if args.regex
+        && let Err(e) = crate::api::regex_validator::validate_regex_pattern(&args.query)
+    {
+        return Err(ToolCallError::InvalidParams(format!("Invalid regex pattern: {e}")));
+    }
+
+    let limit = args.limit.unwrap_or(DEFAULT_SEARCH_LIMIT).clamp(1, MAX_SEARCH_LIMIT);
+    let page = args.page.unwrap_or(1).max(1);
+
+    let search_query = SearchQuery {
+        query: args.query,
+        repository_filter: join_filter(&args.repositories),
+        project_filter: join_filter(&args.projects),
+        version_filter: join_filter(&args.versions),
+        extension_filter: join_filter(&args.extensions),
+        min_size: None,
+        max_size: None,
+        limit: limit as usize,
+        offset: ((page - 1) * limit) as usize,
+        include_facets: false,
+        fuzzy_search: false,
+        regex_search: args.regex,
+        regex_flags: None,
+        case_sensitive: args.case_sensitive,
+    };
+
+    match state.search_service.search(search_query).await {
+        Ok(response) => {
+            let results: Vec<Value> = response
+                .results
+                .into_iter()
+                .map(|r| {
+                    json!({
+                        "repository": r.repository,
+                        "project": r.project,
+                        "version": r.version,
+                        "path": r.file_path,
+                        "extension": r.extension,
+                        "line_number": r.line_number,
+                        "score": r.score,
+                        "snippet": r.content_snippet,
+                        "doc_address": r.doc_address,
+                        "file_id": r.file_id,
+                    })
+                })
+                .collect();
+
+            Ok(crate::mcp::protocol::tool_result(&json!({
+                "total": response.total,
+                "page": page,
+                "limit": limit,
+                "results": results,
+            })))
+        }
+        Err(e) => {
+            tracing::error!("MCP search_code failed: {e}");
+            Ok(crate::mcp::protocol::tool_error(format!("Search failed: {e}")))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GetFileArgs {
+    doc_address: Option<String>,
+    file_id: Option<String>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+}
+
+async fn get_file(state: &AppState, arguments: &Value) -> Result<Value, ToolCallError> {
+    let args: GetFileArgs = parse_args(arguments)?;
+
+    let lookup = if let Some(doc_address) = args.doc_address.as_deref() {
+        state.search_service.get_file_by_doc_address(doc_address).await
+    } else if let Some(file_id) = args.file_id.as_deref() {
+        let uuid = file_id
+            .parse::<uuid::Uuid>()
+            .map_err(|_| ToolCallError::InvalidParams(format!("'file_id' is not a valid UUID: {file_id}")))?;
+        state.search_service.get_file_by_id(uuid).await
+    } else {
+        return Err(ToolCallError::InvalidParams(
+            "Either 'doc_address' or 'file_id' must be provided".to_string(),
+        ));
+    };
+
+    let file = match lookup {
+        Ok(Some(file)) => file,
+        Ok(None) => return Ok(crate::mcp::protocol::tool_error("File not found in the search index")),
+        Err(e) => {
+            tracing::error!("MCP get_file failed: {e}");
+            return Ok(crate::mcp::protocol::tool_error(format!("Failed to fetch file: {e}")));
+        }
+    };
+
+    // For full documents fetched by id/address, content_snippet holds the entire file content
+    let slice = slice_lines(&file.content_snippet, args.start_line, args.end_line, MAX_FILE_LINES);
+
+    Ok(crate::mcp::protocol::tool_result(&json!({
+        "file_id": file.file_id,
+        "name": file.file_name,
+        "path": file.file_path,
+        "repository": file.repository,
+        "project": file.project,
+        "version": file.version,
+        "extension": file.extension,
+        "total_lines": slice.total_lines,
+        "start_line": slice.start_line,
+        "end_line": slice.end_line,
+        "truncated": slice.truncated,
+        "content": slice.content,
+    })))
+}
+
+struct LineSlice {
+    content: String,
+    total_lines: usize,
+    start_line: usize,
+    end_line: usize,
+    truncated: bool,
+}
+
+/// Extract a 1-based inclusive line range from `content`, capped at `max_lines`.
+fn slice_lines(content: &str, start_line: Option<usize>, end_line: Option<usize>, max_lines: usize) -> LineSlice {
+    let lines: Vec<&str> = content.lines().collect();
+    let total_lines = lines.len();
+
+    let start = start_line.unwrap_or(1).max(1);
+    let requested_end = end_line.unwrap_or(total_lines).min(total_lines);
+
+    if start > requested_end || total_lines == 0 {
+        return LineSlice {
+            content: String::new(),
+            total_lines,
+            start_line: start,
+            end_line: start.saturating_sub(1),
+            truncated: false,
+        };
+    }
+
+    let capped_end = requested_end.min(start + max_lines - 1);
+    let truncated = capped_end < requested_end;
+
+    LineSlice {
+        content: lines[start - 1..capped_end].join("\n"),
+        total_lines,
+        start_line: start,
+        end_line: capped_end,
+        truncated,
+    }
+}
+
+async fn list_repositories(state: &AppState) -> Result<Value, ToolCallError> {
+    let repo_repository = RepositoryRepository::new(state.database.pool().clone());
+
+    match repo_repository.list_repositories().await {
+        Ok(repositories) => {
+            // Explicit read-only projection: never expose tokens or crawl configuration
+            let repositories: Vec<Value> = repositories
+                .into_iter()
+                .map(|r| {
+                    json!({
+                        "name": r.name,
+                        "url": r.url,
+                        "repository_type": r.repository_type,
+                        "branch": r.branch,
+                        "enabled": r.enabled,
+                        "last_crawled": r.last_crawled,
+                    })
+                })
+                .collect();
+
+            Ok(crate::mcp::protocol::tool_result(&json!({
+                "total": repositories.len(),
+                "repositories": repositories,
+            })))
+        }
+        Err(e) => {
+            tracing::error!("MCP list_repositories failed: {e}");
+            Ok(crate::mcp::protocol::tool_error(format!(
+                "Failed to list repositories: {e}"
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GetSearchFacetsArgs {
+    query: Option<String>,
+    repositories: Option<Vec<String>>,
+    projects: Option<Vec<String>>,
+    versions: Option<Vec<String>>,
+    extensions: Option<Vec<String>>,
+}
+
+async fn get_search_facets(state: &AppState, arguments: &Value) -> Result<Value, ToolCallError> {
+    let args: GetSearchFacetsArgs = parse_args(arguments)?;
+
+    let query = match args.query {
+        Some(q) if !q.trim().is_empty() => q,
+        _ => "*".to_string(),
+    };
+
+    let search_query = SearchQuery {
+        query,
+        repository_filter: join_filter(&args.repositories),
+        project_filter: join_filter(&args.projects),
+        version_filter: join_filter(&args.versions),
+        extension_filter: join_filter(&args.extensions),
+        min_size: None,
+        max_size: None,
+        limit: 0,
+        offset: 0,
+        include_facets: true,
+        fuzzy_search: false,
+        regex_search: false,
+        regex_flags: None,
+        case_sensitive: false,
+    };
+
+    match state.search_service.search(search_query).await {
+        Ok(response) => {
+            let to_values = |facet: Vec<(String, u64)>| -> Vec<Value> {
+                facet.into_iter().map(|(value, count)| json!({ "value": value, "count": count })).collect()
+            };
+
+            let facets = response.facets.map(|f| {
+                json!({
+                    "repositories": to_values(f.repositories),
+                    "projects": to_values(f.projects),
+                    "versions": to_values(f.versions),
+                    "extensions": to_values(f.extensions),
+                })
+            });
+
+            Ok(crate::mcp::protocol::tool_result(&facets.unwrap_or_else(
+                || json!({ "repositories": [], "projects": [], "versions": [], "extensions": [] }),
+            )))
+        }
+        Err(e) => {
+            tracing::error!("MCP get_search_facets failed: {e}");
+            Ok(crate::mcp::protocol::tool_error(format!(
+                "Failed to compute facets: {e}"
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_definitions_lists_all_tools() {
+        let definitions = tool_definitions();
+        let names: Vec<&str> = definitions.as_array().unwrap().iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert_eq!(
+            names,
+            vec!["search_code", "get_file", "list_repositories", "get_search_facets"]
+        );
+
+        // Every tool must declare an object input schema (required by MCP clients)
+        for tool in definitions.as_array().unwrap() {
+            assert_eq!(tool["inputSchema"]["type"], "object", "tool {} schema", tool["name"]);
+            assert!(tool["description"].as_str().unwrap().len() > 20);
+        }
+    }
+
+    #[test]
+    fn test_join_filter() {
+        assert_eq!(
+            join_filter(&Some(vec!["a".to_string(), " b ".to_string()])),
+            Some("a,b".to_string())
+        );
+        assert_eq!(join_filter(&Some(vec![])), None);
+        assert_eq!(join_filter(&Some(vec!["  ".to_string()])), None);
+        assert_eq!(join_filter(&None), None);
+    }
+
+    #[test]
+    fn test_slice_lines_full_content() {
+        let slice = slice_lines("a\nb\nc", None, None, 100);
+        assert_eq!(slice.content, "a\nb\nc");
+        assert_eq!((slice.start_line, slice.end_line, slice.total_lines), (1, 3, 3));
+        assert!(!slice.truncated);
+    }
+
+    #[test]
+    fn test_slice_lines_range() {
+        let slice = slice_lines("a\nb\nc\nd", Some(2), Some(3), 100);
+        assert_eq!(slice.content, "b\nc");
+        assert_eq!((slice.start_line, slice.end_line), (2, 3));
+    }
+
+    #[test]
+    fn test_slice_lines_truncation() {
+        let content = (1..=10).map(|i| i.to_string()).collect::<Vec<_>>().join("\n");
+        let slice = slice_lines(&content, None, None, 4);
+        assert_eq!(slice.content, "1\n2\n3\n4");
+        assert!(slice.truncated);
+        assert_eq!(slice.end_line, 4);
+        assert_eq!(slice.total_lines, 10);
+    }
+
+    #[test]
+    fn test_slice_lines_out_of_range() {
+        let slice = slice_lines("a\nb", Some(5), None, 100);
+        assert_eq!(slice.content, "");
+        assert!(!slice.truncated);
+        assert_eq!(slice.total_lines, 2);
+    }
+
+    #[test]
+    fn test_search_code_args_parse() {
+        let args: SearchCodeArgs = parse_args(&serde_json::json!({
+            "query": "fn main",
+            "extensions": ["rs"],
+            "regex": false,
+            "limit": 5
+        }))
+        .expect("valid args");
+        assert_eq!(args.query, "fn main");
+        assert_eq!(args.extensions, Some(vec!["rs".to_string()]));
+        assert_eq!(args.limit, Some(5));
+        assert!(!args.case_sensitive);
+    }
+
+    #[test]
+    fn test_get_file_args_parse_null_arguments() {
+        let args: GetFileArgs = parse_args(&Value::Null).expect("null arguments are valid");
+        assert!(args.doc_address.is_none());
+        assert!(args.file_id.is_none());
+    }
+}

--- a/klask-rs/src/mcp/tools.rs
+++ b/klask-rs/src/mcp/tools.rs
@@ -191,6 +191,8 @@ async fn search_code(state: &AppState, arguments: &Value) -> Result<Value, ToolC
 
     let limit = args.limit.unwrap_or(DEFAULT_SEARCH_LIMIT).clamp(1, MAX_SEARCH_LIMIT);
     let page = args.page.unwrap_or(1).max(1);
+    // Compute in u64: (page - 1) * limit overflows u32 for very large pages
+    let offset = ((page as u64 - 1) * limit as u64) as usize;
 
     let search_query = SearchQuery {
         query: args.query,
@@ -201,7 +203,7 @@ async fn search_code(state: &AppState, arguments: &Value) -> Result<Value, ToolC
         min_size: None,
         max_size: None,
         limit: limit as usize,
-        offset: ((page - 1) * limit) as usize,
+        offset,
         include_facets: false,
         fuzzy_search: false,
         regex_search: args.regex,

--- a/klask-rs/src/mcp/tools.rs
+++ b/klask-rs/src/mcp/tools.rs
@@ -18,6 +18,10 @@ const DEFAULT_SEARCH_LIMIT: u32 = 20;
 /// Maximum number of lines returned by `get_file` in a single call.
 const MAX_FILE_LINES: usize = 2000;
 
+/// Maximum number of repositories a single `list_repositories` call can return.
+const MAX_REPOSITORY_LIMIT: u32 = 500;
+const DEFAULT_REPOSITORY_LIMIT: u32 = 100;
+
 /// Protocol-level tool call failures (mapped to JSON-RPC errors by the caller).
 #[derive(Debug)]
 pub enum ToolCallError {
@@ -108,10 +112,27 @@ pub fn tool_definitions() -> Value {
         {
             "name": "list_repositories",
             "description": "List the repositories indexed by Klask with their type (Git, GitLab, \
-                GitHub, FileSystem), URL and last crawl time.",
+                GitHub, FileSystem), URL and last crawl time. Only enabled repositories are \
+                returned unless include_disabled is true; results are paginated.",
             "inputSchema": {
                 "type": "object",
-                "properties": {}
+                "properties": {
+                    "include_disabled": {
+                        "type": "boolean",
+                        "description": "Also return repositories disabled for crawling (default false)"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_REPOSITORY_LIMIT,
+                        "description": "Maximum repositories to return (default 100, max 500)"
+                    },
+                    "page": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Result page, 1-based (default 1)"
+                    }
+                }
             }
         },
         {
@@ -141,7 +162,7 @@ pub async fn call_tool(state: &AppState, name: &str, arguments: &Value) -> Resul
     match name {
         "search_code" => search_code(state, arguments).await,
         "get_file" => get_file(state, arguments).await,
-        "list_repositories" => list_repositories(state).await,
+        "list_repositories" => list_repositories(state, arguments).await,
         "get_search_facets" => get_search_facets(state, arguments).await,
         other => Err(ToolCallError::UnknownTool(other.to_string())),
     }
@@ -336,14 +357,32 @@ fn slice_lines(content: &str, start_line: Option<usize>, end_line: Option<usize>
     }
 }
 
-async fn list_repositories(state: &AppState) -> Result<Value, ToolCallError> {
+#[derive(Debug, Deserialize)]
+struct ListRepositoriesArgs {
+    #[serde(default)]
+    include_disabled: bool,
+    limit: Option<u32>,
+    page: Option<u32>,
+}
+
+async fn list_repositories(state: &AppState, arguments: &Value) -> Result<Value, ToolCallError> {
+    let args: ListRepositoriesArgs = parse_args(arguments)?;
+    let limit = args.limit.unwrap_or(DEFAULT_REPOSITORY_LIMIT).clamp(1, MAX_REPOSITORY_LIMIT) as usize;
+    let page = args.page.unwrap_or(1).max(1);
+    let offset = ((page as u64 - 1) * limit as u64) as usize;
+
     let repo_repository = RepositoryRepository::new(state.database.pool().clone());
 
     match repo_repository.list_repositories().await {
         Ok(repositories) => {
+            let visible: Vec<_> = repositories.into_iter().filter(|r| args.include_disabled || r.enabled).collect();
+            let total = visible.len();
+
             // Explicit read-only projection: never expose tokens or crawl configuration
-            let repositories: Vec<Value> = repositories
+            let repositories: Vec<Value> = visible
                 .into_iter()
+                .skip(offset)
+                .take(limit)
                 .map(|r| {
                     json!({
                         "name": r.name,
@@ -357,7 +396,9 @@ async fn list_repositories(state: &AppState) -> Result<Value, ToolCallError> {
                 .collect();
 
             Ok(crate::mcp::protocol::tool_result(&json!({
-                "total": repositories.len(),
+                "total": total,
+                "page": page,
+                "limit": limit,
                 "repositories": repositories,
             })))
         }
@@ -509,6 +550,20 @@ mod tests {
         assert_eq!(args.extensions, Some(vec!["rs".to_string()]));
         assert_eq!(args.limit, Some(5));
         assert!(!args.case_sensitive);
+    }
+
+    #[test]
+    fn test_list_repositories_args_defaults() {
+        let args: ListRepositoriesArgs = parse_args(&Value::Null).expect("null arguments are valid");
+        assert!(!args.include_disabled);
+        assert!(args.limit.is_none());
+        assert!(args.page.is_none());
+
+        let args: ListRepositoriesArgs =
+            parse_args(&serde_json::json!({ "include_disabled": true, "limit": 5, "page": 2 })).expect("valid args");
+        assert!(args.include_disabled);
+        assert_eq!(args.limit, Some(5));
+        assert_eq!(args.page, Some(2));
     }
 
     #[test]

--- a/klask-rs/src/models/api_token.rs
+++ b/klask-rs/src/models/api_token.rs
@@ -1,0 +1,152 @@
+//! Personal API tokens for programmatic access to Klask
+//!
+//! Tokens follow the format: `klask_pat_` (10 chars) + 32 random alphanumeric characters.
+//! Tokens are hashed using Argon2 before being stored in the database.
+//! The plaintext token is shown to the user only once during creation.
+
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+/// Represents a stored API token (internal use, includes hash)
+#[derive(Debug, Serialize, Deserialize, Clone, FromRow)]
+pub struct ApiToken {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub token_hash: String,
+    pub token_prefix: String,
+    pub name: String,
+    pub scope: String,
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Public representation of an API token (safe to return in API responses)
+/// This struct excludes the token hash for security
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ApiTokenInfo {
+    pub id: Uuid,
+    pub token_prefix: String,
+    pub name: String,
+    pub scope: String,
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Response sent when a new API token is created
+/// This is the only time the plaintext token is revealed to the user
+#[derive(Debug, Serialize)]
+pub struct CreateApiTokenResponse {
+    pub id: Uuid,
+    pub token: String, // Plaintext token (shown only once)
+    pub token_prefix: String,
+    pub name: String,
+    pub scope: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Request to create a new API token
+#[derive(Debug, Deserialize)]
+pub struct CreateApiTokenRequest {
+    pub name: String,
+    #[serde(default)]
+    pub expires_in_days: Option<i32>,
+}
+
+impl From<ApiToken> for ApiTokenInfo {
+    fn from(token: ApiToken) -> Self {
+        Self {
+            id: token.id,
+            token_prefix: token.token_prefix,
+            name: token.name,
+            scope: token.scope,
+            active: token.active,
+            created_at: token.created_at,
+            last_used_at: token.last_used_at,
+            expires_at: token.expires_at,
+        }
+    }
+}
+
+/// Generate a new personal API token with the format: `klask_pat_` + 32 random alphanumeric characters
+///
+/// Total length: 42 characters
+/// Example: `klask_pat_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6`
+pub fn generate_api_token() -> String {
+    use rand::RngExt;
+
+    const PREFIX: &str = "klask_pat_";
+    const RANDOM_CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    const RANDOM_LEN: usize = 32;
+
+    let mut rng = rand::rng();
+    let random_part: String = (0..RANDOM_LEN)
+        .map(|_| {
+            let idx = rng.random_range(0..RANDOM_CHARS.len());
+            RANDOM_CHARS[idx] as char
+        })
+        .collect();
+
+    format!("{}{}", PREFIX, random_part)
+}
+
+/// Extract the display-safe prefix from a full token
+/// The prefix is used in the database to allow listing tokens without exposing the full hash
+///
+/// # Panics
+/// Panics if the token is shorter than 12 characters (expected format)
+pub fn extract_token_prefix(token: &str) -> String {
+    // klask_pat_ = 10 chars, + 2 chars from the random part = 12 total
+    token[0..12].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_api_token() {
+        let token = generate_api_token();
+        assert_eq!(token.len(), 42);
+        assert!(token.starts_with("klask_pat_"));
+    }
+
+    #[test]
+    fn test_generate_api_token_uniqueness() {
+        let token1 = generate_api_token();
+        let token2 = generate_api_token();
+        assert_ne!(token1, token2);
+    }
+
+    #[test]
+    fn test_extract_token_prefix() {
+        let token = "klask_pat_abcdefghij";
+        let prefix = extract_token_prefix(token);
+        assert_eq!(prefix, "klask_pat_ab");
+    }
+
+    #[test]
+    fn test_api_token_to_info_conversion() {
+        let now = chrono::Utc::now();
+        let token = ApiToken {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            token_hash: "hash".to_string(),
+            token_prefix: "klask_pat_ab".to_string(),
+            name: "Test Token".to_string(),
+            scope: "read-only".to_string(),
+            active: true,
+            created_at: now,
+            last_used_at: None,
+            expires_at: None,
+        };
+
+        let info: ApiTokenInfo = token.into();
+        assert_eq!(info.name, "Test Token");
+        assert!(!info.token_prefix.contains("hash")); // Hash should not be in ApiTokenInfo
+    }
+}

--- a/klask-rs/src/models/api_token.rs
+++ b/klask-rs/src/models/api_token.rs
@@ -1,10 +1,11 @@
 //! Personal API tokens for programmatic access to Klask
 //!
 //! Tokens follow the format: `klask_pat_` (10 chars) + 32 random alphanumeric characters.
-//! Tokens are hashed using Argon2 before being stored in the database.
+//! Tokens are hashed using SHA-256 before being stored in the database.
 //! The plaintext token is shown to the user only once during creation.
 
 use serde::{Deserialize, Serialize};
+use sha2::{Sha256, Digest};
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -102,6 +103,14 @@ pub fn generate_api_token() -> String {
 pub fn extract_token_prefix(token: &str) -> String {
     // klask_pat_ = 10 chars, + 2 chars from the random part = 12 total
     token[0..12].to_string()
+}
+
+/// Hash an API token using SHA-256
+/// This is fast and suitable for short-lived, revocable tokens
+pub fn hash_api_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    format!("{:x}", hasher.finalize())
 }
 
 #[cfg(test)]

--- a/klask-rs/src/models/api_token.rs
+++ b/klask-rs/src/models/api_token.rs
@@ -5,7 +5,7 @@
 //! The plaintext token is shown to the user only once during creation.
 
 use serde::{Deserialize, Serialize};
-use sha2::{Sha256, Digest};
+use sha2::{Digest, Sha256};
 use sqlx::FromRow;
 use uuid::Uuid;
 

--- a/klask-rs/src/models/mod.rs
+++ b/klask-rs/src/models/mod.rs
@@ -1,7 +1,9 @@
+pub mod api_token;
 pub mod index_metrics;
 pub mod repository;
 pub mod user;
 
+pub use api_token::*;
 pub use index_metrics::*;
 pub use repository::*;
 pub use user::*;

--- a/klask-rs/src/repositories/api_token_repository.rs
+++ b/klask-rs/src/repositories/api_token_repository.rs
@@ -81,50 +81,28 @@ impl ApiTokenRepository {
     }
 
     /// Find an API token by its plaintext token
-    /// This method handles Argon2 hash comparison for authentication
+    /// Uses SHA-256 hash comparison for fast lookup
     /// Optimized: Uses prefix-based index for O(1) lookup before verifying hash
     pub async fn find_by_token(&self, plaintext_token: &str) -> Result<Option<ApiToken>> {
-        if plaintext_token.len() < 12 {
+        if plaintext_token.len() != 42 || !plaintext_token.starts_with("klask_pat_") {
             return Ok(None);
         }
 
-        let token_prefix = &plaintext_token[0..12];
+        use crate::models::hash_api_token;
+        let token_hash = hash_api_token(plaintext_token);
 
-        let tokens = sqlx::query_as::<_, ApiToken>(
-            "SELECT id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at
-             FROM api_tokens
-             WHERE token_prefix = $1 AND active = true",
-        )
-        .bind(token_prefix)
-        .fetch_all(&self.pool)
-        .await?;
-
-        use crate::utils::password::verify_password;
-
-        for token in tokens {
-            if let Ok(true) = verify_password(plaintext_token, &token.token_hash) {
-                return Ok(Some(token));
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Find an API token by its hash (used during authentication)
-    /// Deprecated: Use find_by_token instead for proper Argon2 verification
-    #[allow(dead_code)]
-    pub async fn find_by_hash(&self, token_hash: &str) -> Result<Option<ApiToken>> {
         let token = sqlx::query_as::<_, ApiToken>(
             "SELECT id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at
              FROM api_tokens
-             WHERE token_hash = $1",
+             WHERE token_hash = $1 AND active = true",
         )
-        .bind(token_hash)
+        .bind(&token_hash)
         .fetch_optional(&self.pool)
         .await?;
 
         Ok(token)
     }
+
 
     /// Update the last_used_at timestamp for a token (called after successful authentication)
     pub async fn update_last_used(&self, id: Uuid) -> Result<()> {

--- a/klask-rs/src/repositories/api_token_repository.rs
+++ b/klask-rs/src/repositories/api_token_repository.rs
@@ -103,7 +103,6 @@ impl ApiTokenRepository {
         Ok(token)
     }
 
-
     /// Update the last_used_at timestamp for a token (called after successful authentication)
     pub async fn update_last_used(&self, id: Uuid) -> Result<()> {
         sqlx::query(

--- a/klask-rs/src/repositories/api_token_repository.rs
+++ b/klask-rs/src/repositories/api_token_repository.rs
@@ -82,18 +82,23 @@ impl ApiTokenRepository {
 
     /// Find an API token by its plaintext token
     /// This method handles Argon2 hash comparison for authentication
+    /// Optimized: Uses prefix-based index for O(1) lookup before verifying hash
     pub async fn find_by_token(&self, plaintext_token: &str) -> Result<Option<ApiToken>> {
-        // Get all tokens (we'll compare hashes in-memory to avoid timing attacks)
-        // In practice, with many tokens, this could be optimized with a prefix index
+        if plaintext_token.len() < 12 {
+            return Ok(None);
+        }
+
+        let token_prefix = &plaintext_token[0..12];
+
         let tokens = sqlx::query_as::<_, ApiToken>(
             "SELECT id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at
              FROM api_tokens
-             LIMIT 10000",
+             WHERE token_prefix = $1 AND active = true",
         )
+        .bind(token_prefix)
         .fetch_all(&self.pool)
         .await?;
 
-        // Use argon2 to verify the plaintext token against each stored hash
         use crate::utils::password::verify_password;
 
         for token in tokens {

--- a/klask-rs/src/repositories/api_token_repository.rs
+++ b/klask-rs/src/repositories/api_token_repository.rs
@@ -1,0 +1,220 @@
+//! Repository for API token CRUD operations
+
+use crate::models::ApiToken;
+use anyhow::Result;
+use chrono::{Duration, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Repository for managing personal API tokens
+pub struct ApiTokenRepository {
+    pool: PgPool,
+}
+
+impl ApiTokenRepository {
+    /// Create a new ApiTokenRepository with the given connection pool
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Create a new API token
+    pub async fn create_token(
+        &self,
+        user_id: Uuid,
+        name: &str,
+        scope: &str,
+        token_hash: &str,
+        token_prefix: &str,
+        expires_in_days: Option<i32>,
+    ) -> Result<ApiToken> {
+        let expires_at =
+            expires_in_days.and_then(
+                |days| {
+                    if days <= 0 { None } else { Some(Utc::now() + Duration::days(days as i64)) }
+                },
+            );
+
+        let result = sqlx::query_as::<_, ApiToken>(
+            "INSERT INTO api_tokens (user_id, name, scope, token_hash, token_prefix, expires_at)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at"
+        )
+        .bind(user_id)
+        .bind(name)
+        .bind(scope)
+        .bind(token_hash)
+        .bind(token_prefix)
+        .bind(expires_at)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(result)
+    }
+
+    /// List all active API tokens for a given user
+    pub async fn list_tokens(&self, user_id: Uuid) -> Result<Vec<ApiToken>> {
+        let tokens = sqlx::query_as::<_, ApiToken>(
+            "SELECT id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at
+             FROM api_tokens
+             WHERE user_id = $1 AND active = true
+             ORDER BY created_at DESC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(tokens)
+    }
+
+    /// Get a specific API token by ID
+    pub async fn get_token(&self, id: Uuid) -> Result<Option<ApiToken>> {
+        let token = sqlx::query_as::<_, ApiToken>(
+            "SELECT id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at
+             FROM api_tokens
+             WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(token)
+    }
+
+    /// Find an API token by its plaintext token
+    /// This method handles Argon2 hash comparison for authentication
+    pub async fn find_by_token(&self, plaintext_token: &str) -> Result<Option<ApiToken>> {
+        // Get all tokens (we'll compare hashes in-memory to avoid timing attacks)
+        // In practice, with many tokens, this could be optimized with a prefix index
+        let tokens = sqlx::query_as::<_, ApiToken>(
+            "SELECT id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at
+             FROM api_tokens
+             LIMIT 10000",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        // Use argon2 to verify the plaintext token against each stored hash
+        use crate::utils::password::verify_password;
+
+        for token in tokens {
+            if let Ok(true) = verify_password(plaintext_token, &token.token_hash) {
+                return Ok(Some(token));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Find an API token by its hash (used during authentication)
+    /// Deprecated: Use find_by_token instead for proper Argon2 verification
+    #[allow(dead_code)]
+    pub async fn find_by_hash(&self, token_hash: &str) -> Result<Option<ApiToken>> {
+        let token = sqlx::query_as::<_, ApiToken>(
+            "SELECT id, user_id, token_hash, token_prefix, name, scope, active, created_at, last_used_at, expires_at
+             FROM api_tokens
+             WHERE token_hash = $1",
+        )
+        .bind(token_hash)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(token)
+    }
+
+    /// Update the last_used_at timestamp for a token (called after successful authentication)
+    pub async fn update_last_used(&self, id: Uuid) -> Result<()> {
+        sqlx::query(
+            "UPDATE api_tokens
+             SET last_used_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Revoke an API token (soft delete: set active = false)
+    pub async fn revoke_token(&self, id: Uuid) -> Result<()> {
+        sqlx::query(
+            "UPDATE api_tokens
+             SET active = false
+             WHERE id = $1",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Revoke all active API tokens for a given user (e.g., after password change)
+    #[allow(dead_code)]
+    pub async fn revoke_all_for_user(&self, user_id: Uuid) -> Result<()> {
+        sqlx::query(
+            "UPDATE api_tokens
+             SET active = false
+             WHERE user_id = $1 AND active = true",
+        )
+        .bind(user_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Hard delete an API token (use with caution; soft delete via revoke_token is preferred for audit trail)
+    #[allow(dead_code)]
+    pub async fn delete_token(&self, id: Uuid) -> Result<()> {
+        sqlx::query("DELETE FROM api_tokens WHERE id = $1").bind(id).execute(&self.pool).await?;
+
+        Ok(())
+    }
+
+    /// Check if a token exists, is active, and not expired
+    #[allow(dead_code)]
+    pub async fn is_token_valid(&self, token: &ApiToken) -> Result<bool> {
+        if !token.active {
+            return Ok(false);
+        }
+
+        if let Some(expires_at) = token.expires_at
+            && Utc::now() > expires_at
+        {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: Full repository tests would require a test database setup.
+    // Integration tests are recommended for testing database operations.
+    // See tests/ directory for integration test examples.
+
+    #[test]
+    fn test_is_token_valid_not_active() {
+        // Note: This is a simplified test; real tests would use a test database
+        let token = ApiToken {
+            id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            token_hash: "hash".to_string(),
+            token_prefix: "klask_pat_ab".to_string(),
+            name: "Test".to_string(),
+            scope: "read-only".to_string(),
+            active: false,
+            created_at: Utc::now(),
+            last_used_at: None,
+            expires_at: None,
+        };
+
+        // In real integration tests, we'd call the repository method
+        // For now, we verify the token fields are correct
+        assert!(!token.active);
+    }
+}

--- a/klask-rs/src/repositories/mod.rs
+++ b/klask-rs/src/repositories/mod.rs
@@ -1,8 +1,10 @@
+pub mod api_token_repository;
 pub mod repository_repository;
 pub mod user_repository;
 
 #[cfg(any(test, debug_assertions))]
 pub mod test_user_repository;
 
+pub use api_token_repository::*;
 pub use repository_repository::*;
 pub use user_repository::*;

--- a/klask-rs/src/services/search.rs
+++ b/klask-rs/src/services/search.rs
@@ -416,7 +416,9 @@ impl SearchService {
         // full UUID would silently match nothing.
         let file_id_str = file_data.file_id.to_string();
         if let Some(query) = self.file_id_query(file_data.file_id)? {
-            let _ = writer.delete_query(query);
+            // Propagate failures: indexing the new document without having deleted
+            // the old ones would silently accumulate duplicates.
+            writer.delete_query(query)?;
         }
 
         // Check for oversized content that might cause token length issues

--- a/klask-rs/src/services/search.rs
+++ b/klask-rs/src/services/search.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tantivy::collector::{Count, TopDocs};
 use tantivy::directory::MmapDirectory;
-use tantivy::query::{BooleanQuery, QueryParser, RegexQuery, TermQuery};
+use tantivy::query::{BooleanQuery, PhraseQuery, Query, QueryParser, RegexQuery, TermQuery};
 use tantivy::schema::{
     FAST, Field, IndexRecordOption, STORED, STRING, Schema, TEXT, TextFieldIndexing, TextOptions, Value,
 };
@@ -1348,10 +1348,28 @@ impl SearchService {
         let searcher = self.reader.searcher();
         debug!("Getting file by id: {}", file_id);
 
-        // Use a targeted query to find the document with the matching file_id
+        // The file_id field is indexed as TEXT: the default tokenizer lowercases and
+        // splits the UUID on hyphens, so an exact-term lookup on the full UUID never
+        // matches. Tokenize the UUID the same way and use a phrase query instead.
         let file_id_str = file_id.to_string();
-        let term = tantivy::Term::from_field_text(self.fields.file_id, &file_id_str);
-        let query = TermQuery::new(term, tantivy::schema::IndexRecordOption::Basic);
+        let mut tokenizer = self.index.tokenizer_for_field(self.fields.file_id)?;
+        let mut token_stream = tokenizer.token_stream(&file_id_str);
+        let mut terms = Vec::new();
+        while token_stream.advance() {
+            terms.push(tantivy::Term::from_field_text(
+                self.fields.file_id,
+                &token_stream.token().text,
+            ));
+        }
+
+        let query: Box<dyn Query> = match terms.len() {
+            0 => return Ok(None),
+            1 => Box::new(TermQuery::new(
+                terms.remove(0),
+                tantivy::schema::IndexRecordOption::Basic,
+            )),
+            _ => Box::new(PhraseQuery::new(terms)),
+        };
 
         // Search for the specific document
         let top_docs = searcher.search(&query, &TopDocs::with_limit(1))?;

--- a/klask-rs/src/services/search.rs
+++ b/klask-rs/src/services/search.rs
@@ -411,13 +411,13 @@ impl SearchService {
 
         let writer = self.writer.write().await;
 
-        // Delete ALL existing documents with the same file_id to ensure no duplicates
+        // Delete ALL existing documents with the same file_id to ensure no duplicates.
+        // file_id_query handles the tokenized file_id field; a plain TermQuery on the
+        // full UUID would silently match nothing.
         let file_id_str = file_data.file_id.to_string();
-        let term = tantivy::Term::from_field_text(self.fields.file_id, &file_id_str);
-
-        // Use a query to delete all matching documents
-        let query = TermQuery::new(term.clone(), tantivy::schema::IndexRecordOption::Basic);
-        let _ = writer.delete_query(Box::new(query));
+        if let Some(query) = self.file_id_query(file_data.file_id)? {
+            let _ = writer.delete_query(query);
+        }
 
         // Check for oversized content that might cause token length issues
         if file_data.content.len() > tantivy::tokenizer::MAX_TOKEN_LEN {
@@ -1253,8 +1253,11 @@ impl SearchService {
     #[allow(dead_code)]
     pub async fn delete_file(&self, file_id: Uuid) -> Result<()> {
         let writer = self.writer.write().await;
-        let term = tantivy::Term::from_field_text(self.fields.file_id, &file_id.to_string());
-        writer.delete_term(term);
+        // delete_term on the full UUID would silently match nothing because the
+        // file_id field is tokenized; delete through file_id_query instead.
+        if let Some(query) = self.file_id_query(file_id)? {
+            writer.delete_query(query)?;
+        }
         Ok(())
     }
 
@@ -1344,13 +1347,13 @@ impl SearchService {
         }
     }
 
-    pub async fn get_file_by_id(&self, file_id: Uuid) -> Result<Option<SearchResult>> {
-        let searcher = self.reader.searcher();
-        debug!("Getting file by id: {}", file_id);
-
-        // The file_id field is indexed as TEXT: the default tokenizer lowercases and
-        // splits the UUID on hyphens, so an exact-term lookup on the full UUID never
-        // matches. Tokenize the UUID the same way and use a phrase query instead.
+    /// Build a query matching the document(s) whose file_id equals the given UUID.
+    ///
+    /// The file_id field is indexed as TEXT: the default tokenizer lowercases and
+    /// splits the UUID on hyphens, so an exact-term lookup on the full UUID never
+    /// matches. Tokenize the UUID the same way and match the token sequence as a
+    /// phrase instead. Returns None if tokenization yields nothing.
+    fn file_id_query(&self, file_id: Uuid) -> Result<Option<Box<dyn Query>>> {
         let file_id_str = file_id.to_string();
         let mut tokenizer = self.index.tokenizer_for_field(self.fields.file_id)?;
         let mut token_stream = tokenizer.token_stream(&file_id_str);
@@ -1362,13 +1365,22 @@ impl SearchService {
             ));
         }
 
-        let query: Box<dyn Query> = match terms.len() {
-            0 => return Ok(None),
-            1 => Box::new(TermQuery::new(
+        Ok(match terms.len() {
+            0 => None,
+            1 => Some(Box::new(TermQuery::new(
                 terms.remove(0),
                 tantivy::schema::IndexRecordOption::Basic,
-            )),
-            _ => Box::new(PhraseQuery::new(terms)),
+            ))),
+            _ => Some(Box::new(PhraseQuery::new(terms))),
+        })
+    }
+
+    pub async fn get_file_by_id(&self, file_id: Uuid) -> Result<Option<SearchResult>> {
+        let searcher = self.reader.searcher();
+        debug!("Getting file by id: {}", file_id);
+
+        let Some(query) = self.file_id_query(file_id)? else {
+            return Ok(None);
         };
 
         // Search for the specific document

--- a/klask-rs/tests/crawler_test.rs
+++ b/klask-rs/tests/crawler_test.rs
@@ -8,14 +8,14 @@ use serde_json::json;
 async fn test_crawler_service_initialization() -> Result<()> {
     // Test crawler service initialization parameters
     let initialization_params = json!({
-        "search_index_path": "/tmp/test_search",
+        "search_index_dir": "/tmp/test_search",
         "max_file_size_mb": 100,
         "supported_extensions": [".rs", ".md", ".txt", ".toml", ".json"],
         "concurrent_workers": 4,
         "progress_reporting_interval_ms": 1000
     });
 
-    assert!(initialization_params["search_index_path"].is_string());
+    assert!(initialization_params["search_index_dir"].is_string());
     assert_eq!(initialization_params["max_file_size_mb"].as_u64().unwrap(), 100);
     assert!(initialization_params["supported_extensions"].is_array());
     assert_eq!(initialization_params["concurrent_workers"].as_u64().unwrap(), 4);

--- a/klask-rs/tests/mcp_test.rs
+++ b/klask-rs/tests/mcp_test.rs
@@ -1,0 +1,425 @@
+//! Integration tests for the MCP (Model Context Protocol) server endpoint.
+//!
+//! Covers the Streamable HTTP handshake, tool listing, tool execution against
+//! a real Tantivy index, authentication and JSON-RPC error handling.
+
+use anyhow::Result;
+use axum::http::StatusCode;
+use axum_test::TestServer;
+use klask_rs::{
+    auth::{extractors::AppState, jwt::JwtService},
+    config::{AppConfig, AuthConfig, CorsConfig, CrawlerConfig, DatabaseConfig, SearchConfig, ServerConfig},
+    database::Database,
+    models::UserRole,
+    services::{
+        FileData, SearchService, crawler::CrawlerService, encryption::EncryptionService, progress::ProgressTracker,
+    },
+};
+use serde_json::{Value, json};
+use std::{collections::HashMap, sync::Arc, time::Instant};
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+const TEST_JWT_SECRET: &str = "mcp-test-secret-0123456789abcdef0123456789abcdef";
+
+async fn setup_test_server() -> Result<(TestServer, AppState, TempDir)> {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://klask_user:klask_password@localhost/klask_test".to_string());
+
+    let database = Database::new(&database_url, 5).await?;
+
+    let temp_dir = TempDir::new()?;
+    let index_dir = temp_dir.path().join("index");
+    let search_service = Arc::new(SearchService::new(&index_dir)?);
+
+    let config = AppConfig {
+        server: ServerConfig { host: "127.0.0.1".to_string(), port: 0 },
+        database: DatabaseConfig { url: database_url, max_connections: 5 },
+        search: SearchConfig { index_dir: index_dir.to_string_lossy().to_string(), max_results: 10000 },
+        crawler: CrawlerConfig { temp_dir: temp_dir.path().join("crawler").to_string_lossy().to_string() },
+        auth: AuthConfig {
+            jwt_secret: TEST_JWT_SECRET.to_string(),
+            jwt_expires_in: "1h".to_string(),
+            allow_registration: true,
+        },
+        cors: CorsConfig { allowed_origins: vec![] },
+    };
+
+    let progress_tracker = Arc::new(ProgressTracker::new());
+    let jwt_service = JwtService::new(&config.auth)?;
+    let encryption_service = Arc::new(EncryptionService::new("test-encryption-key-32bytes")?);
+    let crawler_service = Arc::new(CrawlerService::new(
+        database.pool().clone(),
+        search_service.clone(),
+        progress_tracker.clone(),
+        encryption_service.clone(),
+        config.crawler.temp_dir.clone(),
+    )?);
+
+    let app_state = AppState {
+        database,
+        search_service,
+        crawler_service,
+        progress_tracker,
+        scheduler_service: None,
+        jwt_service,
+        encryption_service,
+        config,
+        crawl_tasks: Arc::new(RwLock::new(HashMap::new())),
+        startup_time: Instant::now(),
+        delete_account_rate_limiter: Arc::new(RwLock::new(HashMap::new())),
+        login_rate_limiter: Arc::new(RwLock::new(HashMap::new())),
+    };
+
+    let app = klask_rs::mcp::create_router().with_state(app_state.clone());
+    let server = TestServer::new(app);
+
+    Ok((server, app_state, temp_dir))
+}
+
+/// Create a regular user (unique per test, tests share the database) and a valid token.
+async fn create_user_token(app_state: &AppState) -> Result<String> {
+    let user_id = Uuid::new_v4();
+    let username = format!("mcp_user_{}", &user_id.to_string()[..8]);
+    let now = chrono::Utc::now();
+
+    sqlx::query(
+        "INSERT INTO users (id, username, email, password_hash, role, active, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+    )
+    .bind(user_id)
+    .bind(&username)
+    .bind(format!("{username}@example.com"))
+    .bind("test_hash")
+    .bind(UserRole::User)
+    .bind(true)
+    .bind(now)
+    .bind(now)
+    .execute(app_state.database.pool())
+    .await?;
+
+    let token = app_state.jwt_service.create_token_for_user(user_id, username, UserRole::User.to_string())?;
+    Ok(token)
+}
+
+/// Index a small fixture file and commit so it is searchable.
+async fn index_fixture_file(app_state: &AppState) -> Result<Uuid> {
+    let file_id = Uuid::new_v4();
+    let content =
+        "fn validate_jwt_token(token: &str) -> bool {\n    // verify signature and expiry\n    !token.is_empty()\n}\n";
+
+    app_state
+        .search_service
+        .index_file(FileData {
+            file_id,
+            file_name: "auth.rs",
+            file_path: "src/auth.rs",
+            content,
+            repository: "klask",
+            project: "klask",
+            version: "main",
+            extension: "rs",
+            size: content.len() as u64,
+        })
+        .await?;
+    app_state.search_service.force_flush().await?;
+
+    Ok(file_id)
+}
+
+async fn rpc(server: &TestServer, token: &str, body: &Value) -> axum_test::TestResponse {
+    server.post("/mcp").add_header("Authorization", &format!("Bearer {token}")).json(body).await
+}
+
+/// Extract and parse the JSON payload of a tools/call text result.
+fn tool_payload(response_body: &Value) -> Value {
+    let result = &response_body["result"];
+    assert_eq!(result["isError"], false, "tool call should succeed: {result}");
+    let text = result["content"][0]["text"].as_str().expect("text content");
+    serde_json::from_str(text).expect("tool payload should be valid JSON")
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_initialize_handshake() -> Result<()> {
+    let (server, app_state, _tmp) = setup_test_server().await?;
+    let token = create_user_token(&app_state).await?;
+
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "test-client", "version": "0.0.1" }
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+    assert_eq!(body["jsonrpc"], "2.0");
+    assert_eq!(body["id"], 1);
+    assert_eq!(body["result"]["protocolVersion"], "2025-06-18");
+    assert_eq!(body["result"]["serverInfo"]["name"], "klask");
+    assert!(body["result"]["capabilities"]["tools"].is_object());
+
+    // The follow-up notification must be accepted without a JSON-RPC response
+    let response = rpc(
+        &server,
+        &token,
+        &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    )
+    .await;
+    assert_eq!(response.status_code(), StatusCode::ACCEPTED);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_tools_list() -> Result<()> {
+    let (server, app_state, _tmp) = setup_test_server().await?;
+    let token = create_user_token(&app_state).await?;
+
+    let response = rpc(
+        &server,
+        &token,
+        &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    )
+    .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+    let tools = body["result"]["tools"].as_array().expect("tools array");
+    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    assert_eq!(
+        names,
+        vec!["search_code", "get_file", "list_repositories", "get_search_facets"]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_search_and_get_file_roundtrip() -> Result<()> {
+    let (server, app_state, _tmp) = setup_test_server().await?;
+    let token = create_user_token(&app_state).await?;
+    index_fixture_file(&app_state).await?;
+
+    // Search for the fixture content
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "search_code",
+                "arguments": { "query": "validate_jwt_token", "extensions": ["rs"] }
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let payload = tool_payload(&response.json());
+    assert!(
+        payload["total"].as_u64().unwrap() >= 1,
+        "expected at least one hit: {payload}"
+    );
+    let first = &payload["results"][0];
+    assert_eq!(first["path"], "src/auth.rs");
+    assert_eq!(first["version"], "main");
+    let doc_address = first["doc_address"].as_str().expect("doc_address").to_string();
+
+    // Fetch the full file via its doc_address
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "get_file",
+                "arguments": { "doc_address": doc_address }
+            }
+        }),
+    )
+    .await;
+
+    let payload = tool_payload(&response.json());
+    assert_eq!(payload["path"], "src/auth.rs");
+    assert_eq!(payload["truncated"], false);
+    assert!(payload["content"].as_str().unwrap().contains("validate_jwt_token"));
+
+    // Fetch a single line range, this time via file_id
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "get_file",
+                "arguments": { "file_id": payload["file_id"], "start_line": 2, "end_line": 2 }
+            }
+        }),
+    )
+    .await;
+    let payload = tool_payload(&response.json());
+    assert_eq!(payload["start_line"], 2);
+    assert_eq!(payload["end_line"], 2);
+    assert!(payload["content"].as_str().unwrap().contains("verify signature"));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_get_search_facets() -> Result<()> {
+    let (server, app_state, _tmp) = setup_test_server().await?;
+    let token = create_user_token(&app_state).await?;
+    index_fixture_file(&app_state).await?;
+
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": { "name": "get_search_facets" }
+        }),
+    )
+    .await;
+
+    let payload = tool_payload(&response.json());
+    let extensions = payload["extensions"].as_array().expect("extensions facet");
+    assert!(
+        extensions.iter().any(|f| f["value"] == "rs" && f["count"].as_u64().unwrap() >= 1),
+        "expected an rs facet: {payload}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_list_repositories_empty() -> Result<()> {
+    let (server, app_state, _tmp) = setup_test_server().await?;
+    let token = create_user_token(&app_state).await?;
+
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": { "name": "list_repositories" }
+        }),
+    )
+    .await;
+
+    let payload = tool_payload(&response.json());
+    assert!(payload["repositories"].is_array());
+    assert_eq!(
+        payload["total"].as_u64().unwrap() as usize,
+        payload["repositories"].as_array().unwrap().len()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_requires_authentication() -> Result<()> {
+    let (server, _app_state, _tmp) = setup_test_server().await?;
+
+    let response = server.post("/mcp").json(&json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})).await;
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_protocol_errors() -> Result<()> {
+    let (server, app_state, _tmp) = setup_test_server().await?;
+    let token = create_user_token(&app_state).await?;
+
+    // Unknown method -> -32601
+    let response = rpc(
+        &server,
+        &token,
+        &json!({"jsonrpc": "2.0", "id": 1, "method": "does/not/exist"}),
+    )
+    .await;
+    let body: Value = response.json();
+    assert_eq!(body["error"]["code"], -32601);
+
+    // Malformed JSON -> -32700
+    let response = server
+        .post("/mcp")
+        .add_header("Authorization", &format!("Bearer {token}"))
+        .add_header("Content-Type", "application/json")
+        .text("{not json")
+        .await;
+    let body: Value = response.json();
+    assert_eq!(body["error"]["code"], -32700);
+
+    // Unknown tool -> -32602
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": { "name": "rm_dash_rf", "arguments": {} }
+        }),
+    )
+    .await;
+    let body: Value = response.json();
+    assert_eq!(body["error"]["code"], -32602);
+
+    // Missing required argument -> -32602
+    let response = rpc(
+        &server,
+        &token,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": { "name": "search_code", "arguments": {} }
+        }),
+    )
+    .await;
+    let body: Value = response.json();
+    assert_eq!(body["error"]["code"], -32602);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "Requires PostgreSQL database"]
+async fn test_mcp_get_method_not_allowed() -> Result<()> {
+    let (server, app_state, _tmp) = setup_test_server().await?;
+    let token = create_user_token(&app_state).await?;
+
+    let response = server.get("/mcp").add_header("Authorization", &format!("Bearer {token}")).await;
+    assert_eq!(response.status_code(), StatusCode::METHOD_NOT_ALLOWED);
+
+    Ok(())
+}

--- a/klask-rs/tests/mcp_test.rs
+++ b/klask-rs/tests/mcp_test.rs
@@ -333,11 +333,16 @@ async fn test_mcp_list_repositories_empty() -> Result<()> {
     .await;
 
     let payload = tool_payload(&response.json());
-    assert!(payload["repositories"].is_array());
-    assert_eq!(
-        payload["total"].as_u64().unwrap() as usize,
-        payload["repositories"].as_array().unwrap().len()
-    );
+    let page_len = payload["repositories"].as_array().expect("repositories array").len();
+    let limit = payload["limit"].as_u64().unwrap() as usize;
+    assert_eq!(payload["page"], 1);
+    assert!(page_len <= limit);
+    assert!(payload["total"].as_u64().unwrap() as usize >= page_len);
+
+    // Disabled repositories are excluded by default, so every returned repo is enabled
+    for repo in payload["repositories"].as_array().unwrap() {
+        assert_eq!(repo["enabled"], true, "unexpected disabled repo: {repo}");
+    }
 
     Ok(())
 }

--- a/klask-rs/tests/mcp_test.rs
+++ b/klask-rs/tests/mcp_test.rs
@@ -379,6 +379,12 @@ async fn test_mcp_protocol_errors() -> Result<()> {
     let body: Value = response.json();
     assert_eq!(body["error"]["code"], -32700);
 
+    // Well-formed JSON that is not a valid Request object -> -32600, echoing the id
+    let response = rpc(&server, &token, &json!({"jsonrpc": "2.0", "id": 9})).await;
+    let body: Value = response.json();
+    assert_eq!(body["error"]["code"], -32600);
+    assert_eq!(body["id"], 9);
+
     // Unknown tool -> -32602
     let response = rpc(
         &server,

--- a/klask-rs/tests/search_service_test.rs
+++ b/klask-rs/tests/search_service_test.rs
@@ -1184,4 +1184,77 @@ mod search_service_tests {
             assert_eq!(results.total, 1, "Should find document in cycle {}", cycle);
         }
     }
+
+    #[tokio::test]
+    async fn test_upsert_same_file_id_does_not_duplicate() {
+        let (service, _temp_dir, _guard) = create_test_search_service().await;
+
+        let file_id = Uuid::new_v4();
+        for revision in 0..3 {
+            let content = format!("fn revision_{}() {{}}", revision);
+            let file_data = klask_rs::services::search::FileData {
+                file_id,
+                file_name: "main.rs",
+                file_path: "src/main.rs",
+                content: &content,
+                repository: "test-project",
+                project: "test-project",
+                version: "main",
+                extension: "rs",
+                size: content.len() as u64,
+            };
+            service.upsert_file(file_data).await.unwrap();
+            service.commit().await.unwrap();
+        }
+
+        // Re-indexing the same file_id must replace the document, not duplicate it.
+        // This regression-tests the delete-by-file_id path: the file_id field is
+        // tokenized, so a naive full-UUID term delete silently matches nothing.
+        assert_eq!(
+            service.get_document_count().unwrap(),
+            1,
+            "Upserting the same file_id three times should leave exactly one document"
+        );
+
+        // The surviving document must be the latest revision
+        let file = service.get_file_by_id(file_id).await.unwrap().expect("file should be found by id");
+        assert!(
+            file.content_snippet.contains("revision_2"),
+            "Surviving document should hold the latest content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_file_removes_document() {
+        let (service, _temp_dir, _guard) = create_test_search_service().await;
+
+        let file_id = Uuid::new_v4();
+        let file_data = klask_rs::services::search::FileData {
+            file_id,
+            file_name: "to_delete.rs",
+            file_path: "src/to_delete.rs",
+            content: "fn doomed() {}",
+            repository: "test-project",
+            project: "test-project",
+            version: "main",
+            extension: "rs",
+            size: 14,
+        };
+        service.upsert_file(file_data).await.unwrap();
+        service.commit().await.unwrap();
+        assert_eq!(service.get_document_count().unwrap(), 1);
+
+        service.delete_file(file_id).await.unwrap();
+        service.commit().await.unwrap();
+
+        assert_eq!(
+            service.get_document_count().unwrap(),
+            0,
+            "delete_file should remove the document"
+        );
+        assert!(
+            service.get_file_by_id(file_id).await.unwrap().is_none(),
+            "Deleted file should not be found by id"
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds a **stateless, tools-only MCP (Model Context Protocol) server** at `POST /mcp`, so AI coding agents (Claude Code, Cursor, custom agents) can use Klask as their cross-repository code-search backend:

```bash
claude mcp add --transport http klask http://klask.internal:3000/mcp \
  --header "Authorization: Bearer <token>"
```

Full design rationale, transport/auth decisions and rollout phases: [docs/MCP_SERVER_PLAN.md](https://github.com/klask-dev/klask-dev/blob/mcp/docs/MCP_SERVER_PLAN.md)

## How

- **Protocol**: JSON-RPC 2.0 over Streamable HTTP, implemented directly (~5 methods: `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, `ping`) — no new dependency, consistent with the project's lean-dependency philosophy. Protocol version negotiated at `initialize` (2025-06-18 / 2025-03-26 / 2024-11-05).
- **Auth**: reuses the existing `Authorization: Bearer <JWT>` flow via the `AuthenticatedUser` extractor (401 without token). Long-lived personal API tokens are planned as a follow-up (phase 2 in the plan).
- **Tools** (all read-only, thin adapters over existing services):
  - `search_code` — full-text/regex search with repo/project/branch/extension filters, limit capped at 100
  - `get_file` — by `doc_address` or `file_id`, optional line range, truncation at 2000 lines with explicit marker
  - `list_repositories` — explicit projection, never exposes tokens or crawl config
  - `get_search_facets` — discover available repos/projects/branches/extensions

## Bug fixes (found while wiring `get_file`)

The `file_id` field is indexed as `TEXT`, so the default tokenizer splits UUIDs on hyphens. Every code path that built a full-UUID `Term` against it silently matched nothing:

- `get_file_by_id` never found anything (broke `GET /api/files/{id}`)
- `upsert_file`'s dedup delete was a no-op → re-indexing the same file accumulated duplicates
- `delete_file` was a no-op

All three now go through a shared tokenizer-aware `file_id_query` helper, with regression tests. A deeper fix (re-declaring `file_id` as `STRING` in the schema) requires an index rebuild and is left as a follow-up.

## Tests

- Unit tests for the JSON-RPC protocol layer and tool argument handling
- 8 integration tests (`tests/mcp_test.rs`): full handshake, tools/list, search→get_file roundtrip against a real Tantivy index, facets, 401 without auth, JSON-RPC error codes (-32700/-32601/-32602), 405 on GET
- 2 regression tests for upsert dedup / delete_file
- Full suite: 995 tests green, clippy `-D warnings` clean
- Manual smoke test of the real server with curl (handshake + tool calls)

## Security review

Audited: authentication on all paths, no path traversal (reads from the Tantivy index only), no token/secret exposure in tool outputs, regex validation reused from the REST layer, bounded limits. No new vulnerability identified.