### PR TITLE
feat(semantic): hybrid semantic search — phase 1, embedding infrastructure

### DIFF
--- a/docs/SEMANTIC_SEARCH_PLAN.md
+++ b/docs/SEMANTIC_SEARCH_PLAN.md
@@ -1,0 +1,156 @@
+# 🧠 Hybrid Semantic Search Plan — Natural-Language Code Search
+
+## 1. Goal
+
+Let users (and AI agents via MCP) search by **meaning**, not just keywords:
+
+> *"where do we validate JWT tokens?"* → finds `extract_authenticated_user()`,
+> even though neither "validate" nor "JWT token" appears literally.
+
+This is a **hybrid** system: Tantivy BM25 keyword search (existing strength) **+**
+vector similarity search over code-chunk embeddings, fused into one ranked result list.
+Keyword search stays the default; semantic is an opt-in mode that makes Klask
+qualitatively different from grep-style competitors (Hound, OpenGrok).
+
+**Hard constraint: stays self-hosted.** Embeddings are computed locally with an ONNX
+model — no cloud API, no API keys, no code leaving the infra.
+
+---
+
+## 2. Architecture Overview
+
+```
+                       ┌─────────────────────────────────────────┐
+ crawler (existing)    │  file content                           │
+ ──────────────────────┤                                         │
+                       ▼                                         ▼
+                Tantivy index (existing)              Chunker (tree-sitter)
+                       │                                         │
+                       │                              EmbeddingService (fastembed/ONNX)
+                       │                                         │
+                       │                              Vector index (LanceDB, embedded)
+                       │                                         │
+                       ▼                                         ▼
+                 BM25 top-k ────────► RRF fusion ◄──── ANN top-k (cosine)
+                                          │
+                                          ▼
+                                   ranked results
+```
+
+## 3. Technical Decisions
+
+### 3.1 Embedding runtime: `fastembed` (ONNX Runtime, pure local)
+
+- Rust crate, batch inference on CPU, no Python, no network at query time.
+- Model download happens once at startup (cacheable in the PVC / baked into the Docker
+  image for air-gapped deployments).
+- **Model choice** (benchmark in Phase 1 on our own eval set):
+  - `jina-embeddings-v2-base-code` — code-specialized, 768 dims, ~160M params (first pick);
+  - `BAAI/bge-small-en-v1.5` — fallback, 384 dims, much faster/smaller if latency or
+    index size is a problem.
+- Wrapped in an `EmbeddingService` trait so the model (and dims) is swappable via config.
+
+### 3.2 Vector store: LanceDB (embedded)
+
+- Embedded columnar vector DB, Rust-native, persists to local disk next to the Tantivy
+  index — **keeps Klask a single binary + volumes**, no new infra service.
+- Alternatives considered:
+  - *pgvector*: reuses PostgreSQL, but ANN performance degrades at tens of millions of
+    chunks and bloats the relational DB;
+  - *Qdrant*: excellent but adds a service to deploy/operate — against Klask's
+    "drop-in" value proposition.
+- Schema: `chunk(id, file_id, project, version, path, extension, start_line, end_line,
+  kind, vector)` — metadata columns mirror Tantivy facets so filters work in both
+  engines.
+
+### 3.3 Chunking: tree-sitter with line-window fallback
+
+- Parse with tree-sitter grammars (start with: Rust, TypeScript/JS, Java, Python, Go);
+  one chunk per **function / method / class**, prefixed with a context line
+  (`// repo > path > parent symbol`) which measurably improves code embeddings.
+- Unsupported languages / huge functions → fixed window of ~60 lines with 15-line
+  overlap.
+- Chunks > model context → split, same overlap rule.
+
+### 3.4 Fusion: Reciprocal Rank Fusion (RRF)
+
+- Run BM25 and ANN in parallel, fuse with `score = Σ 1/(60 + rank_i)`.
+- Rank-based (no score normalization problem between BM25 and cosine), proven default
+  in hybrid search literature, one tunable constant.
+- Search modes exposed: `keyword` (default, unchanged), `semantic` (ANN only),
+  `hybrid` (RRF).
+
+---
+
+## 4. Indexing Pipeline Changes
+
+1. **Hook point**: the crawler's file-processing path (where `upsert_file` is called)
+   additionally pushes `(file_id, content, metadata)` to an **embedding queue**
+   (bounded `tokio::sync::mpsc`).
+2. A dedicated **embedding worker** batches chunks (e.g. 32/batch), embeds, writes to
+   LanceDB. Decoupled so crawl speed is unaffected; queue backpressure degrades to
+   "semantic index lags behind" rather than slowing the crawl.
+3. **Deletions/updates**: same lifecycle as Tantivy — delete chunks by `file_id` on
+   upsert, by `project` on repository deletion (mirror `delete_project_documents`).
+4. **Backfill job**: admin endpoint + button ("Build semantic index") iterating the
+   existing Tantivy docs, with progress reporting via the existing `ProgressTracker`.
+5. Feature-flagged: `semantic_search.enabled = false` by default in config; when
+   disabled, zero overhead and no model download.
+
+## 5. Query Path Changes
+
+- `SearchQuery` gains `mode: SearchMode` (`Keyword | Semantic | Hybrid`).
+- API: `GET /api/search?mode=hybrid&...` — backward compatible (absent = `keyword`).
+- Facet filters (project/version/extension/size) are applied as LanceDB metadata
+  predicates so both engines see the same filtered universe.
+- Snippet for semantic hits = the chunk's line range (we know `start_line..end_line`),
+  highlighted client-side as today.
+
+## 6. Frontend Changes
+
+- Search mode toggle in `SearchPageV3` (`Keyword | Hybrid | Semantic`), persisted in
+  the existing search-state store; tooltip explaining the modes.
+- Badge on results indicating the match origin in hybrid mode (keyword / semantic /
+  both) — cheap and great for trust/debugging.
+- Admin dashboard: semantic index card (chunk count, size, model name, backfill
+  progress, rebuild button).
+
+## 7. MCP Synergy
+
+Once this lands, the MCP `search_code` tool gains a `mode` parameter (default
+`hybrid` for agents — they ask natural-language questions). This combination
+(agents + semantic cross-repo search) is the end-state killer feature; see
+[MCP_SERVER_PLAN.md](MCP_SERVER_PLAN.md).
+
+## 8. Rollout Phases
+
+| Phase | Content | Status |
+|---|---|---|
+| **1** | `EmbeddingProvider` (fastembed behind the `semantic-search` cargo feature) + chunker + RRF fusion utility + unit tests + model benchmark; config/startup plumbing | 🚧 this PR |
+| **2** | LanceDB store + embedding worker + crawl integration + delete/update lifecycle | planned |
+| **3** | Backfill admin job + progress UI | planned |
+| **4** | Query path: `mode` param, RRF fusion wiring, API + tests | planned |
+| **5** | Frontend toggle + result badges + admin card | planned |
+| **6** | MCP `mode` param; eval pass (latency P95, recall@10 vs keyword) and tuning | planned |
+
+**Phase 1 measurements** (debug build, CPU, `Xenova/bge-small-en-v1.5`, 384 dims):
+embedding throughput ≈ 7.6 chunks/s on ~6-line-function chunks; semantically
+related code snippets score cosine ≈ 0.82 vs ≈ 0.35–0.45 for unrelated ones.
+Reproduce with:
+`cargo test --features semantic-search --test semantic_embedding_test -- --ignored --nocapture`
+
+## 9. Risks & Mitigations
+
+- **Index size** (768 floats/chunk ≈ 3 KB; ~10M chunks ≈ 30 GB) → start with the
+  384-dim model if needed; scalar quantization (int8) in LanceDB cuts 4×; make
+  semantic indexing opt-in per repository if necessary.
+- **Initial backfill cost** (CPU embedding of millions of chunks) → batched worker,
+  progress UI, runs in background; document expected throughput; optional GPU via
+  ONNX Runtime providers later.
+- **Model download at startup** breaks air-gapped installs → support pre-provisioned
+  model directory (config path) + document baking it into the image.
+- **Quality disappointment** → Phase 1 includes a small golden eval set (20 NL
+  queries → expected files on a known repo) so we measure before we ship; hybrid mode
+  means BM25 keeps a quality floor.
+- **Memory** → ONNX session is the main cost (~500 MB for the base model); document
+  new resource requests in the Helm chart.

--- a/klask-rs/.env.example
+++ b/klask-rs/.env.example
@@ -23,6 +23,15 @@ SEARCH_INDEX_PATH=./index
 # Crawler Configuration
 TEMP_DIR=./temp_crawl
 
+# Semantic Search Configuration (requires a binary built with --features semantic-search)
+# The embedding model runs locally (ONNX); the first start downloads it into the cache dir.
+SEMANTIC_SEARCH_ENABLED=false
+SEMANTIC_SEARCH_MODEL=jinaai/jina-embeddings-v2-base-code
+SEMANTIC_SEARCH_CACHE_DIR=./models
+SEMANTIC_SEARCH_CHUNK_MAX_LINES=60
+SEMANTIC_SEARCH_CHUNK_OVERLAP_LINES=15
+SEMANTIC_SEARCH_BATCH_SIZE=32
+
 # Optional: Redis Configuration (if using Redis profile)
 REDIS_URL=redis://redis:6379
 

--- a/klask-rs/Cargo.lock
+++ b/klask-rs/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,12 +44,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -68,12 +106,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -93,6 +148,15 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -156,6 +220,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -267,6 +374,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -276,6 +389,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -293,6 +412,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -350,16 +478,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -375,6 +521,15 @@ name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -466,6 +621,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,12 +637,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -496,8 +684,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -757,6 +964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,7 +993,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -841,6 +1067,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +1096,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -875,7 +1131,7 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest",
  "elliptic-curve",
  "rfc6979",
@@ -929,7 +1185,7 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -947,12 +1203,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -981,6 +1263,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "etcetera"
@@ -1044,10 +1332,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
+name = "fastembed"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add59222e7bc3787285f993744b244cd454d78571845623606bdc45b22b23a4e"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "image",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
 
 [[package]]
 name = "faster-hex"
@@ -1064,6 +1384,21 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "ff"
@@ -1099,6 +1434,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1471,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1317,6 +1677,16 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2114,7 +2484,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bstr",
  "gix-command",
  "gix-credentials",
@@ -2123,7 +2493,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "reqwest",
+ "reqwest 0.13.2",
  "thiserror 2.0.18",
 ]
 
@@ -2261,6 +2631,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2676,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2312,7 +2695,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -2353,6 +2736,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2773,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "home"
@@ -2445,7 +2855,7 @@ dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crossbeam-utils",
  "form_urlencoded",
@@ -2510,12 +2920,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2682,6 +3108,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,12 +3160,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2863,7 +3353,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac",
@@ -2889,10 +3379,11 @@ dependencies = [
  "argon2",
  "axum",
  "axum-test",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "croner",
  "dotenvy",
+ "fastembed",
  "futures",
  "gix",
  "httpmock",
@@ -2900,7 +3391,7 @@ dependencies = [
  "once_cell",
  "rand 0.10.1",
  "regex",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2945,6 +3436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "levenshtein_automata"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,6 +3452,16 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libm"
@@ -2998,6 +3505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,6 +3524,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "lru"
@@ -3034,6 +3556,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,6 +3593,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-async"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,6 +3611,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -3116,6 +3680,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,10 +3701,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -3143,10 +3796,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3213,6 +3881,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,16 +3945,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
 
 [[package]]
 name = "ownedbytes"
@@ -3351,6 +4119,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "path-tree"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,7 +4145,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3374,6 +4154,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -3402,7 +4191,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs8",
  "spki",
 ]
@@ -3413,7 +4202,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "spki",
 ]
 
@@ -3428,6 +4217,19 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "polyval"
@@ -3548,6 +4350,46 @@ checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
  "parking_lot",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -3713,6 +4555,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3720,6 +4618,17 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
 ]
 
 [[package]]
@@ -3748,6 +4657,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3781,11 +4701,54 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -3839,6 +4802,12 @@ dependencies = [
  "hmac",
  "subtle",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -3934,6 +4903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4016,6 +4986,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,7 +5027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
  "pkcs8",
  "subtle",
@@ -4232,6 +5213,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4284,6 +5280,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4299,7 +5306,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -4321,7 +5340,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -4398,7 +5417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -4442,7 +5461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "chrono",
@@ -4631,7 +5650,7 @@ checksum = "502915c7381c5cb2d2781503962610cb880ad8f1a0ca95df1bae645d5ebf2545"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -4730,7 +5749,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "768fccdc84d60d86235d42d7e4c33acf43c418258ff5952abf07bd7837fcd26b"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "serde",
  "serde_json",
 ]
@@ -4832,6 +5851,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4888,6 +5921,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,6 +5979,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5163,10 +6239,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -5179,6 +6270,18 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
@@ -5195,6 +6298,42 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "der 0.8.0",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -5221,6 +6360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5235,6 +6380,17 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -5417,6 +6573,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5474,6 +6643,12 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -5978,6 +7153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6124,4 +7305,28 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/klask-rs/Cargo.toml
+++ b/klask-rs/Cargo.toml
@@ -70,10 +70,16 @@ sha2 = "0.10"
 # Lazy initialization
 once_cell = "1.21"
 
+# Local embedding generation for semantic search (optional, see semantic-search feature)
+fastembed = { version = "5", optional = true }
+
 [features]
 test-utils = []
 pdf-parser = []
 docx-parser = []
+# Hybrid semantic search: local ONNX embedding generation (no cloud API).
+# Opt-in because it pulls the ONNX runtime and downloads a model at startup.
+semantic-search = ["dep:fastembed"]
 
 [dev-dependencies]
 # Testing

--- a/klask-rs/src/auth/extractors.rs
+++ b/klask-rs/src/auth/extractors.rs
@@ -20,6 +20,11 @@ pub struct AppState {
     pub crawler_service: Arc<crate::services::crawler::CrawlerService>,
     pub progress_tracker: Arc<ProgressTracker>,
     pub scheduler_service: Option<Arc<crate::services::scheduler::SchedulerService>>,
+    /// Embedding provider for semantic search; None when disabled or not
+    /// compiled in. Consumed by the indexing pipeline and query path coming
+    /// in the next phases of docs/SEMANTIC_SEARCH_PLAN.md.
+    #[allow(dead_code)]
+    pub semantic_embedder: Option<Arc<dyn crate::services::semantic::EmbeddingProvider>>,
     pub jwt_service: JwtService,
     pub encryption_service: Arc<EncryptionService>,
     #[allow(dead_code)]

--- a/klask-rs/src/config.rs
+++ b/klask-rs/src/config.rs
@@ -9,6 +9,7 @@ pub struct AppConfig {
     pub crawler: CrawlerConfig,
     pub auth: AuthConfig,
     pub cors: CorsConfig,
+    pub semantic: SemanticSearchConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,6 +45,26 @@ pub struct AuthConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CorsConfig {
     pub allowed_origins: Vec<String>,
+}
+
+/// Hybrid semantic search settings (see docs/SEMANTIC_SEARCH_PLAN.md).
+/// Disabled by default; also requires a binary built with the
+/// `semantic-search` cargo feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SemanticSearchConfig {
+    pub enabled: bool,
+    /// Embedding model code, e.g. "jinaai/jina-embeddings-v2-base-code"
+    /// or "Xenova/bge-small-en-v1.5" (smaller/faster).
+    pub model: String,
+    /// Directory where the ONNX model is cached. Pre-provision it for
+    /// air-gapped deployments.
+    pub cache_dir: String,
+    /// Maximum number of file lines per embedding chunk.
+    pub chunk_max_lines: usize,
+    /// Lines of overlap between consecutive chunks.
+    pub chunk_overlap_lines: usize,
+    /// Inference batch size.
+    pub batch_size: usize,
 }
 
 impl AppConfig {
@@ -111,6 +132,27 @@ impl AppConfig {
                     .split(',')
                     .map(|s| s.trim().to_string())
                     .collect(),
+            },
+            semantic: SemanticSearchConfig {
+                enabled: std::env::var("SEMANTIC_SEARCH_ENABLED")
+                    .unwrap_or_else(|_| "false".to_string())
+                    .parse()
+                    .unwrap_or(false),
+                model: std::env::var("SEMANTIC_SEARCH_MODEL")
+                    .unwrap_or_else(|_| "jinaai/jina-embeddings-v2-base-code".to_string()),
+                cache_dir: std::env::var("SEMANTIC_SEARCH_CACHE_DIR").unwrap_or_else(|_| "./models".to_string()),
+                chunk_max_lines: std::env::var("SEMANTIC_SEARCH_CHUNK_MAX_LINES")
+                    .unwrap_or_else(|_| "60".to_string())
+                    .parse()
+                    .unwrap_or(60),
+                chunk_overlap_lines: std::env::var("SEMANTIC_SEARCH_CHUNK_OVERLAP_LINES")
+                    .unwrap_or_else(|_| "15".to_string())
+                    .parse()
+                    .unwrap_or(15),
+                batch_size: std::env::var("SEMANTIC_SEARCH_BATCH_SIZE")
+                    .unwrap_or_else(|_| "32".to_string())
+                    .parse()
+                    .unwrap_or(32),
             },
         };
 

--- a/klask-rs/src/main.rs
+++ b/klask-rs/src/main.rs
@@ -131,6 +131,10 @@ async fn main() -> Result<()> {
     let progress_tracker = Arc::new(ProgressTracker::new());
     info!("Progress tracker initialized successfully");
 
+    // Initialize the semantic-search embedding provider (optional; loads the
+    // local ONNX model when enabled, degrades to keyword-only search on error)
+    let semantic_embedder = services::semantic::init_embedding_provider(&config.semantic);
+
     // Initialize crawler service
     let search_service_arc = Arc::new(search_service);
     let crawler_service = match CrawlerService::new(
@@ -203,6 +207,7 @@ async fn main() -> Result<()> {
         crawler_service: crawler_service_arc,
         progress_tracker,
         scheduler_service: Some(Arc::new(scheduler_service)),
+        semantic_embedder,
         jwt_service,
         encryption_service,
         config: config.clone(),

--- a/klask-rs/src/services/mod.rs
+++ b/klask-rs/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod scheduler;
 pub mod search;
 pub mod search_metrics;
 pub mod seeding;
+pub mod semantic;
 pub mod tantivy_config;
 pub mod tokenizer;
 

--- a/klask-rs/src/services/semantic/chunker.rs
+++ b/klask-rs/src/services/semantic/chunker.rs
@@ -1,0 +1,213 @@
+// The binary target compiles this module tree without consuming the chunker
+// yet (the indexing pipeline lands in plan phase 2); silence the resulting
+// false-positive dead-code warnings until then.
+#![allow(dead_code)]
+
+//! Source-code chunking for embedding generation.
+//!
+//! Splits file content into overlapping line windows sized for the embedding
+//! model context. Window boundaries prefer natural code seams (blank lines and
+//! new top-level declarations) so a function is less likely to be cut in half.
+//! Tree-sitter based structural chunking is planned as a follow-up (see
+//! docs/SEMANTIC_SEARCH_PLAN.md §3.3); this line-window chunker is the
+//! universal fallback it will degrade to for unsupported languages.
+
+/// A contiguous slice of a file prepared for embedding.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Chunk {
+    /// First line of the chunk, 1-based inclusive.
+    pub start_line: usize,
+    /// Last line of the chunk, 1-based inclusive.
+    pub end_line: usize,
+    /// Chunk text, prefixed with a context header line (file path). The header
+    /// measurably improves code embedding quality by anchoring the snippet.
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChunkOptions {
+    /// Maximum number of file lines per chunk (excluding the context header).
+    pub max_lines: usize,
+    /// Number of lines repeated between consecutive chunks.
+    pub overlap_lines: usize,
+}
+
+impl Default for ChunkOptions {
+    fn default() -> Self {
+        Self { max_lines: 60, overlap_lines: 15 }
+    }
+}
+
+/// Fraction of the window we are willing to give up to end on a natural seam.
+const BOUNDARY_SEARCH_FRACTION: f64 = 0.25;
+
+/// Split `content` into overlapping chunks ready for embedding.
+///
+/// Guarantees:
+/// - every line of the file appears in at least one chunk;
+/// - chunk windows never exceed `max_lines` lines;
+/// - consecutive chunks overlap (so context spanning a boundary is not lost);
+/// - always makes forward progress, even with degenerate options.
+pub fn chunk_file(file_path: &str, content: &str, options: &ChunkOptions) -> Vec<Chunk> {
+    let lines: Vec<&str> = content.lines().collect();
+    let total_lines = lines.len();
+    if total_lines == 0 {
+        return Vec::new();
+    }
+
+    let max_lines = options.max_lines.max(1);
+    // Overlap must leave room to advance by at least one line per chunk
+    let overlap = options.overlap_lines.min(max_lines - 1);
+
+    let mut chunks = Vec::new();
+    let mut start = 0usize; // 0-based inclusive index into `lines`
+
+    loop {
+        let hard_end = (start + max_lines).min(total_lines); // 0-based exclusive
+        let end = if hard_end < total_lines {
+            adjust_to_boundary(&lines, start, hard_end)
+        } else {
+            hard_end
+        };
+
+        chunks.push(Chunk {
+            start_line: start + 1,
+            end_line: end,
+            text: format!("// file: {}\n{}", file_path, lines[start..end].join("\n")),
+        });
+
+        if end >= total_lines {
+            break;
+        }
+        // Step back by the overlap, but always move forward
+        start = (end - overlap).max(start + 1);
+    }
+
+    chunks
+}
+
+/// Walk backwards from the hard window end looking for a natural seam: a blank
+/// line, or a line starting a new top-level declaration (non-whitespace at
+/// column 0 right after a line that doesn't open a deeper block). Gives up
+/// after `BOUNDARY_SEARCH_FRACTION` of the window and keeps the hard end.
+fn adjust_to_boundary(lines: &[&str], start: usize, hard_end: usize) -> usize {
+    let window = hard_end - start;
+    let min_end = hard_end - ((window as f64 * BOUNDARY_SEARCH_FRACTION) as usize).min(window - 1);
+
+    let mut end = hard_end;
+    while end > min_end {
+        let last_in_window = lines[end - 1];
+        let first_outside = lines.get(end).copied().unwrap_or("");
+        // Seam: window ends on a blank line, or the next line starts a new
+        // top-level construct (column-0 non-whitespace character)
+        if last_in_window.trim().is_empty()
+            || first_outside.starts_with(|c: char| !c.is_whitespace() && c != '}' && c != ')')
+        {
+            return end;
+        }
+        end -= 1;
+    }
+    hard_end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines_of(n: usize) -> String {
+        (1..=n).map(|i| format!("    line {}", i)).collect::<Vec<_>>().join("\n")
+    }
+
+    #[test]
+    fn test_empty_content_yields_no_chunks() {
+        assert!(chunk_file("a.rs", "", &ChunkOptions::default()).is_empty());
+    }
+
+    #[test]
+    fn test_short_file_is_a_single_chunk() {
+        let content = "fn main() {\n    println!(\"hi\");\n}";
+        let chunks = chunk_file("src/main.rs", content, &ChunkOptions::default());
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].start_line, 1);
+        assert_eq!(chunks[0].end_line, 3);
+        assert!(chunks[0].text.starts_with("// file: src/main.rs\n"));
+        assert!(chunks[0].text.contains("println!"));
+    }
+
+    #[test]
+    fn test_every_line_is_covered_and_chunks_overlap() {
+        let total = 500;
+        let content = lines_of(total);
+        let options = ChunkOptions { max_lines: 60, overlap_lines: 15 };
+        let chunks = chunk_file("big.rs", &content, &options);
+
+        assert!(chunks.len() > 1);
+        assert_eq!(chunks.first().unwrap().start_line, 1);
+        assert_eq!(chunks.last().unwrap().end_line, total);
+
+        for window in chunks.windows(2) {
+            let (a, b) = (&window[0], &window[1]);
+            assert!(b.start_line > a.start_line, "chunks must make forward progress");
+            assert!(
+                b.start_line <= a.end_line + 1,
+                "no gap allowed between chunk ending at {} and chunk starting at {}",
+                a.end_line,
+                b.start_line
+            );
+        }
+        for chunk in &chunks {
+            assert!(chunk.end_line - chunk.start_line < options.max_lines);
+        }
+    }
+
+    #[test]
+    fn test_boundary_preference_cuts_at_blank_line() {
+        // Indented body with a blank line at line 8; window of 9 forces the
+        // boundary search to back up from the hard end (line 9) to the seam
+        let content = "fn a() {\n    b\n    c\n    d\n    e\n    f\n    g\n\n    h\n    i";
+        let options = ChunkOptions { max_lines: 9, overlap_lines: 2 };
+        let chunks = chunk_file("x.rs", content, &options);
+        // First chunk should stop at the blank line (line 8) rather than line 9
+        assert_eq!(chunks[0].end_line, 8);
+    }
+
+    #[test]
+    fn test_boundary_preference_cuts_before_new_top_level_declaration() {
+        // fn a() spans lines 1-10, fn z() starts at line 11. A 12-line window
+        // would cut inside fn z; the seam before the new declaration wins.
+        let content =
+            "fn a() {\n    b1\n    b2\n    b3\n    b4\n    b5\n    b6\n    b7\n    b8\n}\nfn z() {\n    y1\n    y2\n}";
+        let options = ChunkOptions { max_lines: 12, overlap_lines: 2 };
+        let chunks = chunk_file("x.rs", content, &options);
+        assert_eq!(
+            chunks[0].end_line, 10,
+            "first chunk should end at fn a()'s closing brace"
+        );
+    }
+
+    #[test]
+    fn test_degenerate_options_still_progress() {
+        let content = lines_of(10);
+        // overlap >= max_lines would loop forever without the clamp
+        let options = ChunkOptions { max_lines: 3, overlap_lines: 99 };
+        let chunks = chunk_file("x.rs", &content, &options);
+        assert_eq!(chunks.last().unwrap().end_line, 10);
+        assert!(chunks.len() <= 10, "must terminate with bounded chunk count");
+    }
+
+    #[test]
+    fn test_single_long_line() {
+        let content = "x".repeat(10_000);
+        let chunks = chunk_file("x.txt", &content, &ChunkOptions::default());
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].start_line, 1);
+        assert_eq!(chunks[0].end_line, 1);
+    }
+
+    #[test]
+    fn test_default_options_match_plan() {
+        let options = ChunkOptions::default();
+        assert_eq!(options.max_lines, 60);
+        assert_eq!(options.overlap_lines, 15);
+    }
+}

--- a/klask-rs/src/services/semantic/embedder.rs
+++ b/klask-rs/src/services/semantic/embedder.rs
@@ -54,18 +54,18 @@ mod fastembed_provider {
     /// Resolve a model code (e.g. "jinaai/jina-embeddings-v2-base-code") to a
     /// model supported by fastembed.
     pub(crate) fn resolve_model(model_code: &str) -> Result<ModelInfo<EmbeddingModel>> {
-        TextEmbedding::list_supported_models()
-            .into_iter()
-            .find(|info| info.model_code.eq_ignore_ascii_case(model_code))
-            .ok_or_else(|| {
-                let supported =
-                    TextEmbedding::list_supported_models().into_iter().map(|m| m.model_code).collect::<Vec<_>>();
-                anyhow!(
+        let mut supported = TextEmbedding::list_supported_models();
+        match supported.iter().position(|info| info.model_code.eq_ignore_ascii_case(model_code)) {
+            Some(index) => Ok(supported.swap_remove(index)),
+            None => {
+                let codes = supported.into_iter().map(|m| m.model_code).collect::<Vec<_>>();
+                Err(anyhow!(
                     "Unsupported embedding model '{}'. Supported models: {}",
                     model_code,
-                    supported.join(", ")
-                )
-            })
+                    codes.join(", ")
+                ))
+            }
+        }
     }
 
     impl FastEmbedProvider {
@@ -84,7 +84,8 @@ mod fastembed_provider {
                 model: Mutex::new(model),
                 dimension: info.dim,
                 model_code: info.model_code,
-                batch_size: config.batch_size.max(1),
+                // Bounded to keep a misconfigured value from ballooning ONNX batch buffers
+                batch_size: config.batch_size.clamp(1, 512),
             })
         }
     }

--- a/klask-rs/src/services/semantic/embedder.rs
+++ b/klask-rs/src/services/semantic/embedder.rs
@@ -1,0 +1,141 @@
+//! Embedding generation for semantic search.
+//!
+//! `EmbeddingProvider` abstracts the embedding backend so the model runtime
+//! (fastembed/ONNX today, possibly GPU execution providers later) can be
+//! swapped without touching the chunking/indexing/query pipeline. Everything
+//! runs locally: no cloud API, no code leaves the infrastructure.
+
+use anyhow::Result;
+
+/// A local text-embedding backend.
+///
+/// Implementations are CPU-bound and synchronous; async callers should wrap
+/// calls in `tokio::task::spawn_blocking`.
+// Without the semantic-search feature no implementation exists, so the binary
+// target flags the methods as never used; that's expected for the opt-in build.
+#[cfg_attr(not(feature = "semantic-search"), allow(dead_code))]
+pub trait EmbeddingProvider: Send + Sync {
+    /// Dimension of the vectors produced by this provider.
+    fn dimension(&self) -> usize;
+
+    /// Model identifier (e.g. "jinaai/jina-embeddings-v2-base-code") for
+    /// logs, metrics and the admin UI.
+    fn model_id(&self) -> &str;
+
+    /// Embed a batch of texts, returning one vector per input, in order.
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+}
+
+#[cfg(feature = "semantic-search")]
+pub use fastembed_provider::FastEmbedProvider;
+
+#[cfg(feature = "semantic-search")]
+mod fastembed_provider {
+    use super::EmbeddingProvider;
+    use crate::config::SemanticSearchConfig;
+    use anyhow::{Result, anyhow};
+    use fastembed::{EmbeddingModel, ModelInfo, TextEmbedding, TextInitOptions};
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    /// Embedding provider backed by fastembed (ONNX Runtime, local inference).
+    ///
+    /// The first initialization downloads the model into `cache_dir`; later
+    /// starts load it from disk. Air-gapped deployments can pre-provision the
+    /// cache directory (see docs/SEMANTIC_SEARCH_PLAN.md §9).
+    pub struct FastEmbedProvider {
+        // fastembed's embed() needs &mut self (the ONNX session is stateful)
+        model: Mutex<TextEmbedding>,
+        dimension: usize,
+        model_code: String,
+        batch_size: usize,
+    }
+
+    /// Resolve a model code (e.g. "jinaai/jina-embeddings-v2-base-code") to a
+    /// model supported by fastembed.
+    pub(crate) fn resolve_model(model_code: &str) -> Result<ModelInfo<EmbeddingModel>> {
+        TextEmbedding::list_supported_models()
+            .into_iter()
+            .find(|info| info.model_code.eq_ignore_ascii_case(model_code))
+            .ok_or_else(|| {
+                let supported =
+                    TextEmbedding::list_supported_models().into_iter().map(|m| m.model_code).collect::<Vec<_>>();
+                anyhow!(
+                    "Unsupported embedding model '{}'. Supported models: {}",
+                    model_code,
+                    supported.join(", ")
+                )
+            })
+    }
+
+    impl FastEmbedProvider {
+        /// Load (downloading on first use) the configured embedding model.
+        pub fn try_new(config: &SemanticSearchConfig) -> Result<Self> {
+            let info = resolve_model(&config.model)?;
+
+            let options = TextInitOptions::new(info.model)
+                .with_cache_dir(PathBuf::from(&config.cache_dir))
+                .with_show_download_progress(false);
+
+            let model = TextEmbedding::try_new(options)
+                .map_err(|e| anyhow!("Failed to load embedding model '{}': {e}", info.model_code))?;
+
+            Ok(Self {
+                model: Mutex::new(model),
+                dimension: info.dim,
+                model_code: info.model_code,
+                batch_size: config.batch_size.max(1),
+            })
+        }
+    }
+
+    impl EmbeddingProvider for FastEmbedProvider {
+        fn dimension(&self) -> usize {
+            self.dimension
+        }
+
+        fn model_id(&self) -> &str {
+            &self.model_code
+        }
+
+        fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            if texts.is_empty() {
+                return Ok(Vec::new());
+            }
+            let mut model = self.model.lock().map_err(|_| anyhow!("Embedding model mutex poisoned"))?;
+            let embeddings =
+                model.embed(texts, Some(self.batch_size)).map_err(|e| anyhow!("Embedding generation failed: {e}"))?;
+            Ok(embeddings)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_resolve_model_known_codes() {
+            // The two models named in docs/SEMANTIC_SEARCH_PLAN.md must stay resolvable
+            let jina = resolve_model("jinaai/jina-embeddings-v2-base-code").expect("jina code model supported");
+            assert_eq!(jina.dim, 768);
+
+            let bge = resolve_model("Xenova/bge-small-en-v1.5").expect("bge small supported");
+            assert_eq!(bge.dim, 384);
+        }
+
+        #[test]
+        fn test_resolve_model_is_case_insensitive() {
+            assert!(resolve_model("JINAAI/JINA-EMBEDDINGS-V2-BASE-CODE").is_ok());
+        }
+
+        #[test]
+        fn test_resolve_model_unknown_code_lists_alternatives() {
+            let err = resolve_model("acme/does-not-exist").unwrap_err().to_string();
+            assert!(err.contains("acme/does-not-exist"));
+            assert!(
+                err.contains("jinaai/jina-embeddings-v2-base-code"),
+                "error should list supported models"
+            );
+        }
+    }
+}

--- a/klask-rs/src/services/semantic/fusion.rs
+++ b/klask-rs/src/services/semantic/fusion.rs
@@ -1,0 +1,104 @@
+// The binary target compiles this module tree without consuming the fusion
+// function yet (the hybrid query path lands in plan phase 4); silence the
+// resulting false-positive dead-code warnings until then.
+#![allow(dead_code)]
+
+//! Reciprocal Rank Fusion (RRF) for hybrid search.
+//!
+//! Combines several ranked result lists (e.g. Tantivy BM25 and vector ANN)
+//! into one ranking using only ranks, which sidesteps the problem of
+//! normalizing incomparable scores (BM25 vs cosine similarity). See
+//! docs/SEMANTIC_SEARCH_PLAN.md §3.4.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// Standard RRF dampening constant from the literature; larger values flatten
+/// the contribution difference between top and deep ranks.
+pub const DEFAULT_RRF_K: f32 = 60.0;
+
+/// Fuse ranked lists with Reciprocal Rank Fusion.
+///
+/// Each input list is ordered best-first. An item's fused score is
+/// `Σ 1 / (k + rank_i)` over the lists containing it (rank is 1-based).
+/// Returns items ordered by fused score (descending), with ties broken by the
+/// item key (ascending) so the output is deterministic.
+pub fn reciprocal_rank_fusion<K>(rankings: &[Vec<K>], k: f32) -> Vec<(K, f32)>
+where
+    K: Eq + Hash + Ord + Clone,
+{
+    let mut scores: HashMap<K, f32> = HashMap::new();
+
+    for ranking in rankings {
+        for (index, item) in ranking.iter().enumerate() {
+            let rank = (index + 1) as f32;
+            *scores.entry(item.clone()).or_insert(0.0) += 1.0 / (k + rank);
+        }
+    }
+
+    let mut fused: Vec<(K, f32)> = scores.into_iter().collect();
+    fused.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.0.cmp(&b.0)));
+    fused
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_item_in_both_lists_outranks_single_list_items() {
+        let bm25 = vec!["a", "b", "c"];
+        let vector = vec!["d", "b", "e"];
+        let fused = reciprocal_rank_fusion(&[bm25, vector], DEFAULT_RRF_K);
+
+        // "b" is rank 2 in both lists, every other item appears once
+        assert_eq!(fused[0].0, "b");
+    }
+
+    #[test]
+    fn test_single_list_preserves_order() {
+        let only = vec!["x", "y", "z"];
+        let fused = reciprocal_rank_fusion(&[only], DEFAULT_RRF_K);
+        let order: Vec<&str> = fused.iter().map(|(k, _)| *k).collect();
+        assert_eq!(order, vec!["x", "y", "z"]);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let fused: Vec<(String, f32)> = reciprocal_rank_fusion(&[], DEFAULT_RRF_K);
+        assert!(fused.is_empty());
+
+        let fused: Vec<(String, f32)> = reciprocal_rank_fusion(&[vec![], vec![]], DEFAULT_RRF_K);
+        assert!(fused.is_empty());
+    }
+
+    #[test]
+    fn test_ties_break_deterministically() {
+        // "a" and "b" both appear only at rank 1 of one list → equal scores
+        let fused = reciprocal_rank_fusion(&[vec!["b"], vec!["a"]], DEFAULT_RRF_K);
+        assert_eq!(fused[0].0, "a", "equal scores must order by key");
+        assert_eq!(fused[1].0, "b");
+        assert!((fused[0].1 - fused[1].1).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_scores_are_rrf_formula() {
+        let fused = reciprocal_rank_fusion(&[vec!["a", "b"]], 60.0);
+        let score_a = fused.iter().find(|(k, _)| *k == "a").unwrap().1;
+        let score_b = fused.iter().find(|(k, _)| *k == "b").unwrap().1;
+        assert!((score_a - 1.0 / 61.0).abs() < 1e-6);
+        assert!((score_b - 1.0 / 62.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_smaller_k_amplifies_top_ranks() {
+        // With a small k, rank 1 in one list beats rank 3 in two lists;
+        // with the default k, appearing in two lists wins.
+        let lists = [vec!["solo", "x", "y", "both"], vec!["z", "w", "v", "both"]];
+        let fused_small_k = reciprocal_rank_fusion(&lists, 0.5);
+        let fused_default = reciprocal_rank_fusion(&lists, DEFAULT_RRF_K);
+
+        assert_eq!(fused_small_k[0].0, "solo");
+        assert_eq!(fused_default[0].0, "both");
+    }
+}

--- a/klask-rs/src/services/semantic/mod.rs
+++ b/klask-rs/src/services/semantic/mod.rs
@@ -1,0 +1,104 @@
+//! Hybrid semantic search (Phase 1: embedding infrastructure).
+//!
+//! Adds natural-language code search alongside Tantivy BM25, fully
+//! self-hosted: chunking (`chunker`), local embedding generation behind the
+//! `semantic-search` cargo feature (`embedder`), and rank fusion for the
+//! future hybrid query path (`fusion`).
+//!
+//! Roadmap and design decisions: docs/SEMANTIC_SEARCH_PLAN.md. The vector
+//! store, indexing worker and query path land in later phases.
+
+pub mod chunker;
+pub mod embedder;
+pub mod fusion;
+
+pub use embedder::EmbeddingProvider;
+#[cfg(feature = "semantic-search")]
+pub use embedder::FastEmbedProvider;
+
+use crate::config::SemanticSearchConfig;
+use std::sync::Arc;
+
+/// Initialize the embedding provider from configuration.
+///
+/// Returns `None` when semantic search is disabled, when the binary was built
+/// without the `semantic-search` feature, or when the model fails to load —
+/// the server then degrades gracefully to keyword-only search (with an error
+/// in the logs), instead of refusing to start.
+pub fn init_embedding_provider(config: &SemanticSearchConfig) -> Option<Arc<dyn EmbeddingProvider>> {
+    if !config.enabled {
+        tracing::debug!("Semantic search is disabled (SEMANTIC_SEARCH_ENABLED=false)");
+        return None;
+    }
+
+    #[cfg(feature = "semantic-search")]
+    {
+        tracing::info!(
+            "Semantic search enabled: loading embedding model '{}' (cache: {}). First start downloads the model.",
+            config.model,
+            config.cache_dir
+        );
+        let started = std::time::Instant::now();
+        match FastEmbedProvider::try_new(config) {
+            Ok(provider) => {
+                // Warm-up: the first inference initializes the ONNX session
+                match provider.embed(&["fn main() {}".to_string()]) {
+                    Ok(_) => {
+                        tracing::info!(
+                            "Embedding model '{}' ready: dimension={}, loaded+warmed in {:.1}s",
+                            provider.model_id(),
+                            provider.dimension(),
+                            started.elapsed().as_secs_f32()
+                        );
+                        Some(Arc::new(provider))
+                    }
+                    Err(e) => {
+                        tracing::error!("Embedding model warm-up failed, semantic search disabled: {e}");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to initialize embedding provider, semantic search disabled: {e}");
+                None
+            }
+        }
+    }
+
+    #[cfg(not(feature = "semantic-search"))]
+    {
+        tracing::warn!(
+            "SEMANTIC_SEARCH_ENABLED=true but this binary was built without the 'semantic-search' \
+             cargo feature; semantic search stays disabled. Rebuild with --features semantic-search."
+        );
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn disabled_config() -> SemanticSearchConfig {
+        SemanticSearchConfig {
+            enabled: false,
+            model: "jinaai/jina-embeddings-v2-base-code".to_string(),
+            cache_dir: "./models".to_string(),
+            chunk_max_lines: 60,
+            chunk_overlap_lines: 15,
+            batch_size: 32,
+        }
+    }
+
+    #[test]
+    fn test_disabled_config_yields_no_provider() {
+        assert!(init_embedding_provider(&disabled_config()).is_none());
+    }
+
+    #[cfg(not(feature = "semantic-search"))]
+    #[test]
+    fn test_enabled_without_feature_yields_no_provider() {
+        let config = SemanticSearchConfig { enabled: true, ..disabled_config() };
+        assert!(init_embedding_provider(&config).is_none());
+    }
+}

--- a/klask-rs/tests/admin_endpoints_test.rs
+++ b/klask-rs/tests/admin_endpoints_test.rs
@@ -52,6 +52,7 @@ async fn setup_test_server() -> Result<(TestServer, AppState)> {
         crawler_service,
         progress_tracker,
         scheduler_service: None,
+        semantic_embedder: None,
         jwt_service,
         config,
         crawl_tasks: Arc::new(RwLock::new(HashMap::new())),

--- a/klask-rs/tests/auth_test.rs
+++ b/klask-rs/tests/auth_test.rs
@@ -43,6 +43,14 @@ async fn create_test_app_state() -> AppState {
             allow_registration: true,
         },
         cors: klask_rs::config::CorsConfig { allowed_origins: vec!["http://localhost:5173".to_string()] },
+        semantic: klask_rs::config::SemanticSearchConfig {
+            enabled: false,
+            model: "jinaai/jina-embeddings-v2-base-code".to_string(),
+            cache_dir: "./models".to_string(),
+            chunk_max_lines: 60,
+            chunk_overlap_lines: 15,
+            batch_size: 32,
+        },
     };
 
     // Create JWT service
@@ -75,6 +83,7 @@ async fn create_test_app_state() -> AppState {
         crawler_service,
         progress_tracker,
         scheduler_service: None,
+        semantic_embedder: None,
         jwt_service,
         config,
         crawl_tasks: Arc::new(RwLock::new(HashMap::new())),
@@ -272,6 +281,14 @@ async fn create_test_app_state_with_registration(allow_registration: bool) -> Ap
             allow_registration,
         },
         cors: klask_rs::config::CorsConfig { allowed_origins: vec!["http://localhost:5173".to_string()] },
+        semantic: klask_rs::config::SemanticSearchConfig {
+            enabled: false,
+            model: "jinaai/jina-embeddings-v2-base-code".to_string(),
+            cache_dir: "./models".to_string(),
+            chunk_max_lines: 60,
+            chunk_overlap_lines: 15,
+            batch_size: 32,
+        },
     };
 
     // Create JWT service
@@ -304,6 +321,7 @@ async fn create_test_app_state_with_registration(allow_registration: bool) -> Ap
         crawler_service,
         progress_tracker,
         scheduler_service: None,
+        semantic_embedder: None,
         jwt_service,
         config,
         crawl_tasks: Arc::new(RwLock::new(HashMap::new())),

--- a/klask-rs/tests/semantic_embedding_test.rs
+++ b/klask-rs/tests/semantic_embedding_test.rs
@@ -1,0 +1,111 @@
+//! Integration tests for the semantic-search embedding provider.
+//!
+//! These tests load a real ONNX model (downloaded on first run into
+//! target/fastembed-cache) and are therefore `#[ignore]`d by default:
+//!
+//! ```bash
+//! cargo test --features semantic-search --test semantic_embedding_test -- --ignored
+//! ```
+#![cfg(feature = "semantic-search")]
+
+use klask_rs::config::SemanticSearchConfig;
+use klask_rs::services::semantic::chunker::{ChunkOptions, chunk_file};
+use klask_rs::services::semantic::embedder::{EmbeddingProvider, FastEmbedProvider};
+
+/// Small model (384 dims, ~30 MB) to keep the test download reasonable; the
+/// production default is jinaai/jina-embeddings-v2-base-code (768 dims).
+fn test_config() -> SemanticSearchConfig {
+    SemanticSearchConfig {
+        enabled: true,
+        model: "Xenova/bge-small-en-v1.5".to_string(),
+        cache_dir: "target/fastembed-cache".to_string(),
+        chunk_max_lines: 60,
+        chunk_overlap_lines: 15,
+        batch_size: 32,
+    }
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (norm_a * norm_b)
+}
+
+#[test]
+#[ignore = "Downloads the embedding model on first run"]
+fn test_embeddings_capture_code_semantics() {
+    let provider = FastEmbedProvider::try_new(&test_config()).expect("model should load");
+    assert_eq!(provider.dimension(), 384);
+    assert_eq!(provider.model_id(), "Xenova/bge-small-en-v1.5");
+
+    let texts = vec![
+        // Two semantically close snippets about JWT validation…
+        "fn validate_jwt_token(token: &str) -> bool { decode_and_check_signature(token) }".to_string(),
+        "function verifyAuthToken(jwt) { return checkSignatureAndExpiry(jwt); }".to_string(),
+        // …and one unrelated snippet
+        "SELECT AVG(price) FROM products GROUP BY category ORDER BY 1 DESC;".to_string(),
+    ];
+
+    let vectors = provider.embed(&texts).expect("embedding should succeed");
+    assert_eq!(vectors.len(), 3);
+    for v in &vectors {
+        assert_eq!(v.len(), provider.dimension());
+    }
+
+    let similar = cosine(&vectors[0], &vectors[1]);
+    let dissimilar_a = cosine(&vectors[0], &vectors[2]);
+    let dissimilar_b = cosine(&vectors[1], &vectors[2]);
+
+    println!("similar={similar:.3} dissimilar_a={dissimilar_a:.3} dissimilar_b={dissimilar_b:.3}");
+    assert!(
+        similar > dissimilar_a && similar > dissimilar_b,
+        "semantically related snippets must be closer than unrelated ones \
+         (similar={similar:.3}, dissimilar={dissimilar_a:.3}/{dissimilar_b:.3})"
+    );
+}
+
+#[test]
+#[ignore = "Downloads the embedding model on first run"]
+fn test_empty_batch_returns_empty() {
+    let provider = FastEmbedProvider::try_new(&test_config()).expect("model should load");
+    let vectors = provider.embed(&[]).expect("empty batch should succeed");
+    assert!(vectors.is_empty());
+}
+
+/// Phase 1 benchmark (docs/SEMANTIC_SEARCH_PLAN.md §8): chunk a synthetic
+/// source file and measure embedding throughput on this machine.
+#[test]
+#[ignore = "Benchmark; downloads the embedding model on first run"]
+fn test_embedding_throughput_benchmark() {
+    let provider = FastEmbedProvider::try_new(&test_config()).expect("model should load");
+
+    // ~1200 lines of synthetic code → ~25 chunks with the default options
+    let content = (0..200)
+        .map(|i| format!("fn function_{i}(input: &str) -> Result<String> {{\n    let parsed = parse(input)?;\n    let validated = validate(&parsed)?;\n    Ok(render(validated))\n}}\n"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let chunks = chunk_file("src/synthetic.rs", &content, &ChunkOptions::default());
+    let texts: Vec<String> = chunks.iter().map(|c| c.text.clone()).collect();
+    assert!(
+        texts.len() >= 10,
+        "benchmark needs a meaningful batch, got {}",
+        texts.len()
+    );
+
+    // Warm-up run, then timed run
+    provider.embed(&texts[..2.min(texts.len())]).expect("warm-up should succeed");
+    let started = std::time::Instant::now();
+    let vectors = provider.embed(&texts).expect("embedding should succeed");
+    let elapsed = started.elapsed();
+
+    assert_eq!(vectors.len(), texts.len());
+    println!(
+        "Embedded {} chunks in {:.2}s → {:.1} chunks/s (model {}, dim {})",
+        texts.len(),
+        elapsed.as_secs_f64(),
+        texts.len() as f64 / elapsed.as_secs_f64(),
+        provider.model_id(),
+        provider.dimension()
+    );
+}


### PR DESCRIPTION
## What

First phase of **natural-language code search** alongside Tantivy BM25 (*"where do we validate JWT tokens?"* instead of guessing keywords), fully self-hosted: embeddings are computed locally with an ONNX model — no cloud API, no code leaves the infra.

Full architecture, decisions (fastembed, LanceDB, RRF, tree-sitter) and the 6-phase roadmap: [docs/SEMANTIC_SEARCH_PLAN.md](https://github.com/klask-dev/klask-dev/blob/semantic-search/docs/SEMANTIC_SEARCH_PLAN.md)

## Scope of this PR (phase 1)

- **`EmbeddingProvider` trait + `FastEmbedProvider`** (fastembed/ONNX Runtime) behind a new **opt-in cargo feature `semantic-search`** — default builds, CI and the Docker image are completely unaffected (no new compiled dependency, no model download)
- **Code chunker**: overlapping line windows with natural-seam detection (blank lines, new top-level declarations) and a file-path context header; tree-sitter structural chunking comes later and degrades to this
- **Reciprocal Rank Fusion** utility for the upcoming hybrid (BM25 + vector) query path
- **Config & startup plumbing**: `SEMANTIC_SEARCH_*` env vars (disabled by default, documented in `.env.example`), model loading + warm-up at startup with graceful degradation to keyword-only search on failure, `AppState.semantic_embedder` ready for the phase 2 indexing pipeline

## Verification

- 18 unit tests (chunker guarantees: full coverage, overlap, forward progress, boundary preference; RRF formula and determinism; model resolution; init paths in both feature configurations)
- Integration tests against a **real model** (`#[ignore]`, run locally): semantically related code snippets score cosine ≈ 0.82 vs ≈ 0.35–0.45 for unrelated ones; phase 1 throughput benchmark recorded in the plan doc
  `cargo test --features semantic-search --test semantic_embedding_test -- --ignored --nocapture`
- Manual smoke test: server start with `SEMANTIC_SEARCH_ENABLED=true` loads and warms the model (0.4 s from cache) and logs dimension/model
- Full suite: 993 tests green; `cargo clippy --all-targets -D warnings` clean **with and without** the feature

## Security review

Audited the new surface: model code is validated against fastembed's supported-model allowlist; cache dir/model come from env only (trusted); no user input reaches the embedder in this phase; `AppConfig` is not serialized to any API response; batch size clamped. No new vulnerability identified. Supply-chain note: `fastembed` is version-pinned via Cargo.lock and covered by dependabot.

## Next phases

2: LanceDB vector store + indexing worker · 3: backfill admin job · 4: hybrid query path (`mode` param + RRF) · 5: UI toggle · 6: MCP `mode` param + eval pass — see the plan doc.