### PR TITLE
feat(semantic): phase 2 — LanceDB vector store, embedding worker & crawl integration

### DIFF
--- a/docs/SEMANTIC_SEARCH_PLAN.md
+++ b/docs/SEMANTIC_SEARCH_PLAN.md
@@ -126,8 +126,8 @@ Once this lands, the MCP `search_code` tool gains a `mode` parameter (default
 
 | Phase | Content | Status |
 |---|---|---|
-| **1** | `EmbeddingProvider` (fastembed behind the `semantic-search` cargo feature) + chunker + RRF fusion utility + unit tests + model benchmark; config/startup plumbing | 🚧 this PR |
-| **2** | LanceDB store + embedding worker + crawl integration + delete/update lifecycle | planned |
+| **1** | `EmbeddingProvider` (fastembed behind the `semantic-search` cargo feature) + chunker + RRF fusion utility + unit tests + model benchmark; config/startup plumbing | ✅ done (PR #120) |
+| **2** | LanceDB store + embedding worker + crawl integration + delete/update lifecycle | ✅ done (this PR) |
 | **3** | Backfill admin job + progress UI | planned |
 | **4** | Query path: `mode` param, RRF fusion wiring, API + tests | planned |
 | **5** | Frontend toggle + result badges + admin card | planned |
@@ -138,6 +138,24 @@ embedding throughput ≈ 7.6 chunks/s on ~6-line-function chunks; semantically
 related code snippets score cosine ≈ 0.82 vs ≈ 0.35–0.45 for unrelated ones.
 Reproduce with:
 `cargo test --features semantic-search --test semantic_embedding_test -- --ignored --nocapture`
+
+**Phase 2 notes:**
+- Vector store is **LanceDB** (`lancedb` 0.30, embedded), table `chunks` with the
+  metadata columns from §3.2 + a `FixedSizeList<Float32, dim>` vector column.
+  Persists under `SEMANTIC_SEARCH_VECTOR_DIR` (default `./vector-index`).
+- The embedding worker is a single `tokio` task fed by a **bounded** queue;
+  **the crawl blocks when the queue is full** (strict backpressure — chunks are
+  never silently dropped, keeping the vector index consistent with the crawl).
+- Lifecycle mirrors Tantivy: delete-then-insert per `file_id` on upsert,
+  delete-by-`repository` on re-crawl and repository deletion. Re-opening the
+  store with a different embedding dimension (model change) is refused with a
+  clear error to prevent silent corruption.
+- **Build dependency:** lancedb→lance pulls `prost`, which needs `protoc`
+  (Protocol Buffers compiler) at build time. Building with
+  `--features semantic-search` requires `protobuf-compiler` installed; this must
+  be added to the Dockerfile / CI when the feature is enabled in deployment.
+- Verify the full write path against a real model + real LanceDB index with:
+  `cargo test --features semantic-search --test semantic_indexing_test -- --ignored --nocapture`
 
 ## 9. Risks & Mitigations
 

--- a/klask-rs/.env.example
+++ b/klask-rs/.env.example
@@ -28,9 +28,13 @@ TEMP_DIR=./temp_crawl
 SEMANTIC_SEARCH_ENABLED=false
 SEMANTIC_SEARCH_MODEL=jinaai/jina-embeddings-v2-base-code
 SEMANTIC_SEARCH_CACHE_DIR=./models
+# Directory for the embedded vector store (LanceDB), sibling of the Tantivy index.
+SEMANTIC_SEARCH_VECTOR_DIR=./vector-index
 SEMANTIC_SEARCH_CHUNK_MAX_LINES=60
 SEMANTIC_SEARCH_CHUNK_OVERLAP_LINES=15
 SEMANTIC_SEARCH_BATCH_SIZE=32
+# Bounded embedding queue: the crawl blocks when full (no chunks dropped).
+SEMANTIC_SEARCH_QUEUE_CAPACITY=1000
 
 # Optional: Redis Configuration (if using Redis profile)
 REDIS_URL=redis://redis:6379

--- a/klask-rs/Cargo.lock
+++ b/klask-rs/Cargo.lock
@@ -50,6 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -82,6 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
  "equator",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -128,7 +144,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -144,10 +160,241 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+ "lz4_flex 0.13.1",
+ "zstd",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde_core",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "as-slice"
@@ -166,6 +413,30 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -190,6 +461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,7 +479,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async_cell"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
 ]
 
 [[package]]
@@ -391,10 +682,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -424,12 +734,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -463,7 +799,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -488,6 +854,29 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bytemuck"
@@ -544,6 +933,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cedarwood"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "census"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +991,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +1045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +1068,23 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -679,6 +1114,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +1159,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -783,7 +1244,7 @@ checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
 dependencies = [
  "chrono",
  "derive_builder",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -824,6 +1285,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +1330,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,8 +1383,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "daachorse"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db756b5eb7d81d31f31f660f4132f8cf5698de52fca144c143d0ae0cbb5f2e06"
 
 [[package]]
 name = "darling"
@@ -925,7 +1423,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -938,7 +1436,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -949,7 +1447,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -960,7 +1458,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -984,6 +1482,641 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "datafusion"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-table",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "datafusion-sql",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.2",
+ "regex",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-ipc",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store",
+ "paste",
+ "sqlparser",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "rand 0.9.2",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "datafusion-doc"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+
+[[package]]
+name = "datafusion-execution"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.2",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "paste",
+ "serde_json",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "base64 0.22.1",
+ "blake2",
+ "blake3",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "md-5",
+ "memchr",
+ "num-traits",
+ "rand 0.9.2",
+ "regex",
+ "sha2",
+ "unicode-segmentation",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "half",
+ "log",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+dependencies = [
+ "datafusion-doc",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "parking_lot",
+ "paste",
+ "petgraph",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+dependencies = [
+ "ahash",
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+dependencies = [
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
+ "indexmap 2.13.0",
+ "log",
+ "regex",
+ "sqlparser",
+]
+
+[[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1035,7 +2168,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1045,7 +2178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1095,7 +2228,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1124,6 +2257,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1218,6 +2357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,7 +2382,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1280,6 +2428,12 @@ dependencies = [
  "home",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ethnum"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -1328,7 +2482,7 @@ checksum = "6e6fdf550180a6c29a28cb9aac262dc0064c25735641d2317f670075e9a469d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1347,6 +2501,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,7 +2521,7 @@ dependencies = [
  "anyhow",
  "hf-hub",
  "image",
- "ndarray",
+ "ndarray 0.17.2",
  "ort",
  "safetensors",
  "serde",
@@ -1432,6 +2592,22 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -1513,6 +2689,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsst"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd0ce0249ac12fd44fcde62d435c36d881952c2f0df4d1de24b45e1dbba5ddb"
+dependencies = [
+ "arrow-array",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+dependencies = [
+ "utf8-ranges",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,7 +2780,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1615,6 +2816,21 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1879,7 +3095,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "gix-path",
  "libc",
@@ -2044,7 +3260,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2102,7 +3318,7 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "filetime",
  "fnv",
@@ -2167,7 +3383,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2267,7 +3483,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -2368,7 +3584,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -2402,7 +3618,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -2503,7 +3719,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2601,6 +3817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,7 +3845,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2638,6 +3860,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -2649,6 +3872,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2679,6 +3908,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2728,6 +3963,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2881,6 +4122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,6 +4160,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3149,6 +4397,17 @@ checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -3189,7 +4448,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3212,6 +4471,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3229,6 +4499,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3241,6 +4520,28 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jieba-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29cfc5dcd898604c6f80363411fa6b6b08e27d1d253d6225b9cb6702ea02fc0"
+dependencies = [
+ "phf_codegen",
+]
+
+[[package]]
+name = "jieba-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3245d6e9d1d5facbd6a23848d6b67e3439738ccbb4fa5a3d65da315ba1a910a2"
+dependencies = [
+ "cedarwood",
+ "jieba-macros",
+ "phf 0.13.1",
+ "regex",
+ "rustc-hash",
+]
 
 [[package]]
 name = "jiff"
@@ -3265,7 +4566,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3324,7 +4625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3345,6 +4646,26 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonb"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb98fb29636087c40ad0d1274d9a30c0c1e83e03ae93f6e7e89247b37fcc6953"
+dependencies = [
+ "byteorder",
+ "ethnum",
+ "fast-float2",
+ "itoa",
+ "jiff",
+ "nom 8.0.0",
+ "num-traits",
+ "ordered-float",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -3371,12 +4692,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "klask-rs"
 version = "2.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
  "argon2",
+ "arrow-array",
+ "arrow-schema",
+ "async-trait",
  "axum",
  "axum-test",
  "base64 0.22.1",
@@ -3388,6 +4721,7 @@ dependencies = [
  "gix",
  "httpmock",
  "jsonwebtoken",
+ "lancedb",
  "once_cell",
  "rand 0.10.1",
  "regex",
@@ -3421,6 +4755,576 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944aca86f4c78f4da04af1c2bf33e664a2826b7af72972ad200d6b9de59019f"
+dependencies = [
+ "arc-swap",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "async_cell",
+ "bitpacking",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "dashmap",
+ "datafusion",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "deepsize",
+ "either",
+ "futures",
+ "half",
+ "humantime",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-table",
+ "lance-tokenizer",
+ "log",
+ "moka",
+ "object_store",
+ "permutation",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.2",
+ "rayon",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-arrow"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "253f4a0a70580c985b91e65e9ca6cad644825a4078de28d8efbacf3ffbd7ecdc"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "half",
+ "jsonb",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-bitpacking"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c4d12521b1945041dd515a56aa0854973138e7ac12111c92572e33e4ecb593"
+dependencies = [
+ "arrayref",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "lance-core"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f84020da5a484e2f07dd1796e09785ed7cd889857ebc4cb77e32ef214ee594"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common",
+ "datafusion-sql",
+ "deepsize",
+ "futures",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "libc",
+ "log",
+ "moka",
+ "num_cpus",
+ "object_store",
+ "pin-project",
+ "prost",
+ "rand 0.9.2",
+ "roaring",
+ "serde_json",
+ "snafu 0.9.1",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-datafusion"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7460597a66534a75987993d4dac5bc330586d99c5b79ae73367dbcbd4e29e576"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "chrono",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "futures",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datagen",
+ "log",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-datagen"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046f5506ed2271cd941a050de7bf535dd3aedc291aadec836a63fa56c5926e3b"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "futures",
+ "half",
+ "hex",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rand_xoshiro",
+ "random_word",
+]
+
+[[package]]
+name = "lance-encoding"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af54edf43dcf9d6a56cc636eb35d457e68373c6448dca3f0891b3325b4a24e6"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "fsst",
+ "futures",
+ "hex",
+ "hyperloglogplus",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-bitpacking",
+ "lance-core",
+ "log",
+ "lz4",
+ "num-traits",
+ "prost",
+ "prost-build",
+ "rand 0.9.2",
+ "strum 0.26.3",
+ "tokio",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
+name = "lance-file"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772ae2d6207995dc1eb28aff9507f78e90b3362b58f311da001e9dc25f3d736"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-encoding",
+ "lance-io",
+ "log",
+ "num-traits",
+ "object_store",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-index"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71fbfb51096a903cb524fe0da716f5f15fbc4a6b6f84cd6dec21abf319c5e84"
+dependencies = [
+ "arc-swap",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-channel",
+ "async-recursion",
+ "async-trait",
+ "bitpacking",
+ "bitvec",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "deepsize",
+ "dirs",
+ "fst",
+ "futures",
+ "half",
+ "itertools 0.13.0",
+ "jieba-rs",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-io",
+ "lance-linalg",
+ "lance-table",
+ "lance-tokenizer",
+ "libm",
+ "log",
+ "ndarray 0.16.1",
+ "num-traits",
+ "object_store",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rangemap",
+ "rayon",
+ "roaring",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "twox-hash",
+ "uuid",
+]
+
+[[package]]
+name = "lance-io"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab8c98ef1b870b20541d27f3ca4efdf7c9f5c25214233be07d231ba88900219"
+dependencies = [
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "http",
+ "io-uring",
+ "lance-arrow",
+ "lance-core",
+ "lance-namespace",
+ "log",
+ "moka",
+ "object_store",
+ "path_abs",
+ "pin-project",
+ "prost",
+ "rand 0.9.2",
+ "serde",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-linalg"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4c51cad0ac780b02dc4da48528479e7693c03e8d05390510bbc69ca2a9a1f1"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "cc",
+ "deepsize",
+ "half",
+ "lance-arrow",
+ "lance-core",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-namespace"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014e8332ca0615506342e0d3af608639864b68396973be14239f09c9f21f1fc2"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "lance-core",
+ "lance-namespace-reqwest-client",
+ "snafu 0.9.1",
+]
+
+[[package]]
+name = "lance-namespace-impls"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d1231906a3cf92dd3dcda7d14a09c4835af6cd2bcd76dfd2481e87f20a282d"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "bytes",
+ "futures",
+ "lance",
+ "lance-core",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-table",
+ "log",
+ "object_store",
+ "rand 0.9.2",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "lance-namespace-reqwest-client"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6369eee4682fb11edf538388b43c61ce288b8302fe89bb40944d7daa7faaae99"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "url",
+]
+
+[[package]]
+name = "lance-table"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16f1355904aea4ebb04ffc70c58c97901e10bde44452b4b021de4a1f329250d"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-file",
+ "lance-io",
+ "log",
+ "object_store",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.2",
+ "rangemap",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.1",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-testing"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3094c2aacbd1fa093d809fc54fa911e3498671ba451041341d7caaa18460e6b2"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "lance-arrow",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-tokenizer"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39b7f5ed9d0c0b716bf599b559d888267ed1dfe4c4e29d3648b51d2a28940cf"
+dependencies = [
+ "jieba-rs",
+ "lindera",
+ "rust-stemmers",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "lancedb"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db595d8da6c1fbf41ef6a547f27a73cc1105d83a837e8c76ce08743a3c09260"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-sql",
+ "futures",
+ "half",
+ "lance",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-namespace-impls",
+ "lance-table",
+ "lance-testing",
+ "lazy_static",
+ "log",
+ "moka",
+ "num-traits",
+ "object_store",
+ "pin-project",
+ "rand 0.9.2",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "snafu 0.8.9",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,6 +5350,63 @@ name = "levenshtein_automata"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
 
 [[package]]
 name = "libc"
@@ -3475,7 +5436,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -3490,6 +5451,60 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "lindera"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74cda79d7161e99b414e4d292ff673cc3f8d22f070d8be3b6185c033363a9216"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "kanaria",
+ "lindera-dictionary",
+ "log",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "url",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2385456ca9fe87c29072c5f156b52fdd5e28d5b5738ddfb3979501dbd736530"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "derive_builder",
+ "encoding_rs",
+ "encoding_rs_io",
+ "glob",
+ "log",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "regex",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3526,6 +5541,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,10 +5578,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "lzma-rust2"
@@ -3599,7 +5655,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
+ "num_cpus",
+ "once_cell",
  "rawpointer",
+ "thread-tree",
 ]
 
 [[package]]
@@ -3610,7 +5669,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3701,6 +5760,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "monostate"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,7 +5798,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3730,6 +5809,32 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3753,6 +5858,21 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -3888,7 +6008,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3933,6 +6053,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,7 +6106,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -3978,7 +6134,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3994,7 +6150,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4022,12 +6178,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "ndarray",
+ "ndarray 0.17.2",
  "ort-sys",
  "smallvec",
  "tracing",
@@ -4140,6 +6305,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "std_prelude",
+ "stfu8",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4172,6 +6349,101 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "permutation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -4224,7 +6496,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4299,7 +6571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4330,7 +6602,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4367,7 +6639,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4469,6 +6812,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4555,6 +6913,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "random_word"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
+dependencies = [
+ "ahash",
+ "brotli",
+ "paste",
+ "rand 0.9.2",
+ "unicase",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,7 +6966,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -4627,7 +7023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -4647,7 +7043,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4656,7 +7052,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4668,6 +7064,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4700,6 +7116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4721,9 +7146,13 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4731,6 +7160,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4824,6 +7254,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap 2.13.0",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4889,7 +7359,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5015,6 +7485,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,7 +7540,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5062,6 +7562,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -5090,7 +7596,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5128,6 +7634,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5137,6 +7654,51 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5228,6 +7790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5244,6 +7812,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -5267,6 +7841,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive 0.8.9",
+]
+
+[[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive 0.9.1",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5322,6 +7938,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5353,7 +7990,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "once_cell",
@@ -5382,7 +8019,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5405,7 +8042,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -5418,7 +8055,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -5462,7 +8099,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -5532,6 +8169,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
+name = "stfu8"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
 name = "stringmetrics"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,11 +8205,42 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5572,7 +8252,19 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5580,6 +8272,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -5609,7 +8312,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5618,7 +8321,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5643,6 +8346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tantivy"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5663,11 +8372,11 @@ dependencies = [
  "fs4",
  "htmlescape",
  "hyperloglogplus",
- "itertools",
+ "itertools 0.14.0",
  "levenshtein_automata",
  "log",
  "lru",
- "lz4_flex",
+ "lz4_flex 0.11.6",
  "measure_time",
  "memmap2",
  "once_cell",
@@ -5711,7 +8420,7 @@ checksum = "8b628488ae936c83e92b5c4056833054ca56f76c0e616aee8339e24ac89119cd"
 dependencies = [
  "downcast-rs",
  "fastdivide",
- "itertools",
+ "itertools 0.14.0",
  "serde",
  "tantivy-bitpacker",
  "tantivy-common",
@@ -5761,7 +8470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8292095d1a8a2c2b36380ec455f910ab52dde516af36321af332c93f20ab7d5"
 dependencies = [
  "futures-util",
- "itertools",
+ "itertools 0.14.0",
  "tantivy-bitpacker",
  "tantivy-common",
  "tantivy-fst",
@@ -5775,7 +8484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d38a379411169f0b3002c9cba61cdfe315f757e9d4f239c00c282497a0749d"
 dependencies = [
  "murmurhash32",
- "rand_distr",
+ "rand_distr 0.4.3",
  "tantivy-common",
 ]
 
@@ -5787,6 +8496,12 @@ checksum = "23024f6aeb25ceb1a0e27740c84bdb0fae52626737b7e9a9de6ad5aa25c7b038"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -5827,7 +8542,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5838,7 +8553,16 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thread-tree"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbd370cb847953a25954d9f63e14824a36113f8c72eecf6eccef5dc4b45d630"
+dependencies = [
+ "crossbeam-channel",
 ]
 
 [[package]]
@@ -5896,6 +8620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5933,7 +8666,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -5978,7 +8711,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6010,6 +8743,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6058,7 +8792,8 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "async-compression",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6112,7 +8847,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6161,6 +8896,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6193,7 +8937,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6216,6 +8960,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
 
 [[package]]
 name = "unicode-bom"
@@ -6292,6 +9042,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6421,7 +9177,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6537,7 +9293,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -6567,7 +9323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6591,9 +9347,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -6712,7 +9468,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6723,7 +9479,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7086,9 +9842,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7104,7 +9860,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7116,8 +9872,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -7136,7 +9892,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -7151,6 +9907,21 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "y4m"
@@ -7183,7 +9954,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7204,7 +9975,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7224,7 +9995,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7264,7 +10035,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/klask-rs/Cargo.toml
+++ b/klask-rs/Cargo.toml
@@ -73,13 +73,23 @@ once_cell = "1.21"
 # Local embedding generation for semantic search (optional, see semantic-search feature)
 fastembed = { version = "5", optional = true }
 
+# Embedded vector store for semantic search (optional, see semantic-search feature).
+# arrow-array/arrow-schema are pinned to the version lancedb re-exports so the
+# RecordBatch/Schema types we build match the ones lancedb's API expects.
+lancedb = { version = "0.30", optional = true }
+arrow-array = { version = "58", optional = true }
+arrow-schema = { version = "58", optional = true }
+# async fn in object-safe traits (Arc<dyn VectorStore>); native async-fn-in-trait
+# is not yet dyn-compatible.
+async-trait = { version = "0.1", optional = true }
+
 [features]
 test-utils = []
 pdf-parser = []
 docx-parser = []
 # Hybrid semantic search: local ONNX embedding generation (no cloud API).
 # Opt-in because it pulls the ONNX runtime and downloads a model at startup.
-semantic-search = ["dep:fastembed"]
+semantic-search = ["dep:fastembed", "dep:lancedb", "dep:arrow-array", "dep:arrow-schema", "dep:async-trait"]
 
 [dev-dependencies]
 # Testing

--- a/klask-rs/src/api/repositories.rs
+++ b/klask-rs/src/api/repositories.rs
@@ -938,6 +938,18 @@ async fn delete_repository(
                 }
             }
 
+            // Mirror the cleanup in the semantic vector store (best-effort).
+            #[cfg(feature = "semantic-search")]
+            if let Some(indexer) = &app_state.semantic_indexer {
+                match indexer.delete_project(&repository.name).await {
+                    Ok(n) => info!("Deleted {} semantic chunks for repository: {}", n, repository.name),
+                    Err(e) => warn!(
+                        "Failed to delete semantic chunks for repository {}: {}",
+                        repository.name, e
+                    ),
+                }
+            }
+
             // Delete the repository from database
             match repo_repository.delete_repository(id).await {
                 Ok(_) => {
@@ -1298,6 +1310,18 @@ async fn bulk_delete_repositories(
                             repository.name, e
                         );
                         index_cleanup_failures += 1;
+                    }
+                }
+
+                // Mirror the cleanup in the semantic vector store (best-effort).
+                #[cfg(feature = "semantic-search")]
+                if let Some(indexer) = &app_state.semantic_indexer {
+                    match indexer.delete_project(&repository.name).await {
+                        Ok(n) => debug!("Deleted {} semantic chunks for repository: {}", n, repository.name),
+                        Err(e) => warn!(
+                            "Failed to delete semantic chunks for repository {}: {}",
+                            repository.name, e
+                        ),
                     }
                 }
 

--- a/klask-rs/src/auth/extractors.rs
+++ b/klask-rs/src/auth/extractors.rs
@@ -21,10 +21,14 @@ pub struct AppState {
     pub progress_tracker: Arc<ProgressTracker>,
     pub scheduler_service: Option<Arc<crate::services::scheduler::SchedulerService>>,
     /// Embedding provider for semantic search; None when disabled or not
-    /// compiled in. Consumed by the indexing pipeline and query path coming
-    /// in the next phases of docs/SEMANTIC_SEARCH_PLAN.md.
+    /// compiled in. Used by the query path (embed the query text) coming in
+    /// Phase 4 of docs/SEMANTIC_SEARCH_PLAN.md.
     #[allow(dead_code)]
     pub semantic_embedder: Option<Arc<dyn crate::services::semantic::EmbeddingProvider>>,
+    /// Background embedding worker that mirrors crawled files into the vector
+    /// store. None when semantic search is disabled or not compiled in.
+    #[allow(dead_code)]
+    pub semantic_indexer: crate::services::semantic::MaybeIndexer,
     pub jwt_service: JwtService,
     pub encryption_service: Arc<EncryptionService>,
     #[allow(dead_code)]

--- a/klask-rs/src/config.rs
+++ b/klask-rs/src/config.rs
@@ -59,12 +59,19 @@ pub struct SemanticSearchConfig {
     /// Directory where the ONNX model is cached. Pre-provision it for
     /// air-gapped deployments.
     pub cache_dir: String,
+    /// Directory where the embedded vector store (LanceDB) persists, sibling of
+    /// the Tantivy index.
+    pub vector_store_dir: String,
     /// Maximum number of file lines per embedding chunk.
     pub chunk_max_lines: usize,
     /// Lines of overlap between consecutive chunks.
     pub chunk_overlap_lines: usize,
     /// Inference batch size.
     pub batch_size: usize,
+    /// Bounded embedding-queue capacity. The crawl blocks when the queue is
+    /// full (strict backpressure), so this caps in-flight files awaiting
+    /// embedding rather than dropping work.
+    pub queue_capacity: usize,
 }
 
 impl AppConfig {
@@ -141,6 +148,8 @@ impl AppConfig {
                 model: std::env::var("SEMANTIC_SEARCH_MODEL")
                     .unwrap_or_else(|_| "jinaai/jina-embeddings-v2-base-code".to_string()),
                 cache_dir: std::env::var("SEMANTIC_SEARCH_CACHE_DIR").unwrap_or_else(|_| "./models".to_string()),
+                vector_store_dir: std::env::var("SEMANTIC_SEARCH_VECTOR_DIR")
+                    .unwrap_or_else(|_| "./vector-index".to_string()),
                 chunk_max_lines: std::env::var("SEMANTIC_SEARCH_CHUNK_MAX_LINES")
                     .unwrap_or_else(|_| "60".to_string())
                     .parse()
@@ -153,6 +162,10 @@ impl AppConfig {
                     .unwrap_or_else(|_| "32".to_string())
                     .parse()
                     .unwrap_or(32),
+                queue_capacity: std::env::var("SEMANTIC_SEARCH_QUEUE_CAPACITY")
+                    .unwrap_or_else(|_| "1000".to_string())
+                    .parse()
+                    .unwrap_or(1000),
             },
         };
 

--- a/klask-rs/src/main.rs
+++ b/klask-rs/src/main.rs
@@ -135,6 +135,17 @@ async fn main() -> Result<()> {
     // local ONNX model when enabled, degrades to keyword-only search on error)
     let semantic_embedder = services::semantic::init_embedding_provider(&config.semantic);
 
+    // Open the vector store and start the embedding worker (optional; degrades
+    // to keyword-only indexing if the store can't be opened). Only when the
+    // provider loaded successfully — the indexer needs it to embed chunks.
+    #[cfg(feature = "semantic-search")]
+    let semantic_indexer: services::semantic::MaybeIndexer = match &semantic_embedder {
+        Some(provider) => services::semantic::init_vector_indexer(&config.semantic, provider.clone()).await,
+        None => None,
+    };
+    #[cfg(not(feature = "semantic-search"))]
+    let semantic_indexer: services::semantic::MaybeIndexer = None;
+
     // Initialize crawler service
     let search_service_arc = Arc::new(search_service);
     let crawler_service = match CrawlerService::new(
@@ -143,6 +154,7 @@ async fn main() -> Result<()> {
         progress_tracker.clone(),
         encryption_service.clone(),
         config.crawler.temp_dir.clone(),
+        semantic_indexer.clone(),
     ) {
         Ok(service) => {
             info!("Crawler service initialized successfully");
@@ -208,6 +220,7 @@ async fn main() -> Result<()> {
         progress_tracker,
         scheduler_service: Some(Arc::new(scheduler_service)),
         semantic_embedder,
+        semantic_indexer,
         jwt_service,
         encryption_service,
         config: config.clone(),

--- a/klask-rs/src/services/crawler/branch_processor.rs
+++ b/klask-rs/src/services/crawler/branch_processor.rs
@@ -36,8 +36,12 @@ pub struct BranchProcessor {
 }
 
 impl BranchProcessor {
-    pub fn new(search_service: Arc<SearchService>, progress_tracker: Arc<ProgressTracker>) -> Self {
-        let file_processor = FileProcessor::new(search_service.clone());
+    pub fn new(
+        search_service: Arc<SearchService>,
+        progress_tracker: Arc<ProgressTracker>,
+        semantic_indexer: crate::services::semantic::MaybeIndexer,
+    ) -> Self {
+        let file_processor = FileProcessor::new(search_service.clone(), semantic_indexer);
         Self { progress_tracker, file_processor }
     }
 

--- a/klask-rs/src/services/crawler/file_processing.rs
+++ b/klask-rs/src/services/crawler/file_processing.rs
@@ -5,6 +5,8 @@ use anyhow::Result;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(feature = "semantic-search")]
+use tracing::warn;
 use tracing::{debug, error};
 use uuid::Uuid;
 
@@ -12,11 +14,16 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub struct FileProcessor {
     search_service: Arc<SearchService>,
+    /// Optional semantic indexer: mirrors each indexed file into the vector
+    /// store. None when semantic search is disabled / not compiled in. Read only
+    /// in the `semantic-search` build.
+    #[cfg_attr(not(feature = "semantic-search"), allow(dead_code))]
+    semantic_indexer: crate::services::semantic::MaybeIndexer,
 }
 
 impl FileProcessor {
-    pub fn new(search_service: Arc<SearchService>) -> Self {
-        Self { search_service }
+    pub fn new(search_service: Arc<SearchService>, semantic_indexer: crate::services::semantic::MaybeIndexer) -> Self {
+        Self { search_service, semantic_indexer }
     }
 
     /// Generate a deterministic UUID for a file based on repository, specific branch, and path
@@ -170,6 +177,26 @@ impl FileProcessor {
                     relative_path, branch_name, e
                 );
                 return Err(e);
+            }
+        }
+
+        // Mirror the file into the semantic vector store (best-effort). Tantivy
+        // is the source of truth; a failed/blocked embed must not fail the
+        // crawl — Phase 3 backfill reconciles any gap. With strict backpressure
+        // this `await` may pause the crawl until the embedding queue drains.
+        #[cfg(feature = "semantic-search")]
+        if let Some(indexer) = &self.semantic_indexer {
+            let job = crate::services::semantic::IndexJob {
+                file_id,
+                repository: repository_field.to_string(),
+                project: repository.name.clone(),
+                version: version.clone(),
+                path: relative_path.to_string(),
+                extension: extension.clone(),
+                content: content.clone(),
+            };
+            if let Err(e) = indexer.index_file(job).await {
+                warn!("Failed to enqueue {} for semantic indexing: {}", relative_path, e);
             }
         }
 

--- a/klask-rs/src/services/crawler/github_crawler.rs
+++ b/klask-rs/src/services/crawler/github_crawler.rs
@@ -21,6 +21,8 @@ pub struct GitHubCrawler {
     progress_tracker: Arc<ProgressTracker>,
     encryption_service: Arc<EncryptionService>,
     temp_dir: PathBuf,
+    #[cfg_attr(not(feature = "semantic-search"), allow(dead_code))]
+    semantic_indexer: crate::services::semantic::MaybeIndexer,
 }
 
 impl GitHubCrawler {
@@ -30,8 +32,9 @@ impl GitHubCrawler {
         progress_tracker: Arc<ProgressTracker>,
         encryption_service: Arc<EncryptionService>,
         temp_dir: PathBuf,
+        semantic_indexer: crate::services::semantic::MaybeIndexer,
     ) -> Self {
-        Self { database, search_service, progress_tracker, encryption_service, temp_dir }
+        Self { database, search_service, progress_tracker, encryption_service, temp_dir, semantic_indexer }
     }
 
     /// Crawl a GitHub repository by discovering all sub-repositories and cloning them
@@ -89,6 +92,22 @@ impl GitHubCrawler {
                     repository.name, e
                 );
                 // Continue anyway - the upsert should handle duplicates
+            }
+        }
+
+        // Mirror the deletion in the semantic vector store (best-effort).
+        #[cfg(feature = "semantic-search")]
+        if let Some(indexer) = &self.semantic_indexer {
+            match indexer.delete_project(&repository.name).await {
+                Ok(n) if n > 0 => info!(
+                    "Deleted {} semantic chunks for GitHub repository {}",
+                    n, repository.name
+                ),
+                Ok(_) => {}
+                Err(e) => warn!(
+                    "Failed to delete semantic chunks for GitHub repository {}: {}",
+                    repository.name, e
+                ),
             }
         }
 

--- a/klask-rs/src/services/crawler/gitlab_crawler.rs
+++ b/klask-rs/src/services/crawler/gitlab_crawler.rs
@@ -21,6 +21,8 @@ pub struct GitLabCrawler {
     progress_tracker: Arc<ProgressTracker>,
     encryption_service: Arc<EncryptionService>,
     temp_dir: PathBuf,
+    #[cfg_attr(not(feature = "semantic-search"), allow(dead_code))]
+    semantic_indexer: crate::services::semantic::MaybeIndexer,
 }
 
 impl GitLabCrawler {
@@ -30,8 +32,9 @@ impl GitLabCrawler {
         progress_tracker: Arc<ProgressTracker>,
         encryption_service: Arc<EncryptionService>,
         temp_dir: PathBuf,
+        semantic_indexer: crate::services::semantic::MaybeIndexer,
     ) -> Self {
-        Self { database, search_service, progress_tracker, encryption_service, temp_dir }
+        Self { database, search_service, progress_tracker, encryption_service, temp_dir, semantic_indexer }
     }
 
     /// Crawl a GitLab repository by discovering all sub-projects and cloning them
@@ -89,6 +92,22 @@ impl GitLabCrawler {
                     repository.name, e
                 );
                 // Continue anyway - the upsert should handle duplicates
+            }
+        }
+
+        // Mirror the deletion in the semantic vector store (best-effort).
+        #[cfg(feature = "semantic-search")]
+        if let Some(indexer) = &self.semantic_indexer {
+            match indexer.delete_project(&repository.name).await {
+                Ok(n) if n > 0 => info!(
+                    "Deleted {} semantic chunks for GitLab repository {}",
+                    n, repository.name
+                ),
+                Ok(_) => {}
+                Err(e) => warn!(
+                    "Failed to delete semantic chunks for GitLab repository {}: {}",
+                    repository.name, e
+                ),
             }
         }
 

--- a/klask-rs/src/services/crawler/service.rs
+++ b/klask-rs/src/services/crawler/service.rs
@@ -26,6 +26,10 @@ pub struct CrawlerService {
     encryption_service: Arc<EncryptionService>,
     pub temp_dir: PathBuf,
     cancellation_tokens: Arc<RwLock<HashMap<Uuid, CancellationToken>>>,
+    /// Optional semantic indexer, mirrored into the specialized crawlers so they
+    /// can keep the vector store in sync on delete. None when disabled.
+    #[cfg_attr(not(feature = "semantic-search"), allow(dead_code))]
+    semantic_indexer: crate::services::semantic::MaybeIndexer,
     // Specialized crawlers
     git_operations: GitOperations,
     branch_processor: BranchProcessor,
@@ -40,19 +44,25 @@ impl CrawlerService {
         progress_tracker: Arc<ProgressTracker>,
         encryption_service: Arc<EncryptionService>,
         temp_dir: String,
+        semantic_indexer: crate::services::semantic::MaybeIndexer,
     ) -> Result<Self> {
         let temp_dir = std::path::PathBuf::from(temp_dir);
         std::fs::create_dir_all(&temp_dir).map_err(|e| anyhow!("Failed to create temp directory: {}", e))?;
 
         // Create specialized crawlers
         let git_operations = GitOperations::new(encryption_service.clone());
-        let branch_processor = BranchProcessor::new(search_service.clone(), progress_tracker.clone());
+        let branch_processor = BranchProcessor::new(
+            search_service.clone(),
+            progress_tracker.clone(),
+            semantic_indexer.clone(),
+        );
         let gitlab_crawler = GitLabCrawler::new(
             database.clone(),
             search_service.clone(),
             progress_tracker.clone(),
             encryption_service.clone(),
             temp_dir.clone(),
+            semantic_indexer.clone(),
         );
         let github_crawler = GitHubCrawler::new(
             database.clone(),
@@ -60,6 +70,7 @@ impl CrawlerService {
             progress_tracker.clone(),
             encryption_service.clone(),
             temp_dir.clone(),
+            semantic_indexer.clone(),
         );
 
         Ok(Self {
@@ -69,6 +80,7 @@ impl CrawlerService {
             encryption_service,
             temp_dir,
             cancellation_tokens: Arc::new(RwLock::new(HashMap::new())),
+            semantic_indexer,
             git_operations,
             branch_processor,
             gitlab_crawler,
@@ -143,6 +155,20 @@ impl CrawlerService {
                     repository.name, e
                 );
                 // Continue anyway - the upsert should handle duplicates
+            }
+        }
+
+        // Mirror the deletion in the semantic vector store before re-crawling so
+        // stale chunks don't linger (best-effort; mirrors the Tantivy cleanup).
+        #[cfg(feature = "semantic-search")]
+        if let Some(indexer) = &self.semantic_indexer {
+            match indexer.delete_project(&repository.name).await {
+                Ok(n) if n > 0 => info!("Deleted {} semantic chunks for repository {}", n, repository.name),
+                Ok(_) => {}
+                Err(e) => warn!(
+                    "Failed to delete semantic chunks for repository {}: {}",
+                    repository.name, e
+                ),
             }
         }
 
@@ -751,14 +777,20 @@ impl Clone for CrawlerService {
             encryption_service: self.encryption_service.clone(),
             temp_dir: self.temp_dir.clone(),
             cancellation_tokens: self.cancellation_tokens.clone(),
+            semantic_indexer: self.semantic_indexer.clone(),
             git_operations: GitOperations::new(self.encryption_service.clone()),
-            branch_processor: BranchProcessor::new(self.search_service.clone(), self.progress_tracker.clone()),
+            branch_processor: BranchProcessor::new(
+                self.search_service.clone(),
+                self.progress_tracker.clone(),
+                self.semantic_indexer.clone(),
+            ),
             gitlab_crawler: GitLabCrawler::new(
                 self.database.clone(),
                 self.search_service.clone(),
                 self.progress_tracker.clone(),
                 self.encryption_service.clone(),
                 self.temp_dir.clone(),
+                self.semantic_indexer.clone(),
             ),
             github_crawler: GitHubCrawler::new(
                 self.database.clone(),
@@ -766,6 +798,7 @@ impl Clone for CrawlerService {
                 self.progress_tracker.clone(),
                 self.encryption_service.clone(),
                 self.temp_dir.clone(),
+                self.semantic_indexer.clone(),
             ),
         }
     }

--- a/klask-rs/src/services/semantic/indexer.rs
+++ b/klask-rs/src/services/semantic/indexer.rs
@@ -1,0 +1,310 @@
+//! Background embedding worker that feeds the vector store.
+//!
+//! The crawler hands files to [`VectorIndexer`] via a bounded channel; a single
+//! worker task chunks each file, embeds the chunks with the local
+//! [`EmbeddingProvider`], and upserts them into the [`VectorStore`]. Decoupling
+//! embedding from the crawl keeps ONNX inference off the crawl's hot path and
+//! funnels all inference through one ONNX session (the provider serializes
+//! internally), avoiding lock contention and unbounded parallel-batch memory.
+//!
+//! Backpressure is strict: when the queue is full the crawl *awaits* capacity
+//! (it does not drop work), so the vector index stays consistent with what was
+//! crawled. See docs/SEMANTIC_SEARCH_PLAN.md §4.
+//!
+//! Gated on the `semantic-search` feature (it depends on the vector store).
+#![cfg(feature = "semantic-search")]
+
+use super::chunker::{ChunkOptions, chunk_file};
+use super::embedder::EmbeddingProvider;
+use super::store::{ChunkRecord, VectorStore};
+use anyhow::{Result, anyhow};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+/// A single file to embed and store. Owns its content so the crawl can move on.
+#[derive(Debug, Clone)]
+pub struct IndexJob {
+    pub file_id: Uuid,
+    pub repository: String,
+    pub project: String,
+    pub version: String,
+    pub path: String,
+    pub extension: String,
+    pub content: String,
+}
+
+/// Handle to the background embedding worker.
+///
+/// Cheap to clone (it only holds an `mpsc::Sender`). Held by `AppState` and the
+/// crawler. Dropping all clones closes the channel, which drains and stops the
+/// worker gracefully.
+#[derive(Clone)]
+pub struct VectorIndexer {
+    tx: mpsc::Sender<IndexJob>,
+    store: Arc<dyn VectorStore>,
+}
+
+impl VectorIndexer {
+    /// Spawn the worker and return a handle.
+    ///
+    /// `batch_size` caps how many chunks are embedded per inference call;
+    /// `capacity` bounds the queue (and thus the crawl's backpressure point).
+    pub fn start(
+        provider: Arc<dyn EmbeddingProvider>,
+        store: Arc<dyn VectorStore>,
+        chunk_options: ChunkOptions,
+        batch_size: usize,
+        capacity: usize,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(capacity.max(1));
+        let worker = Worker { provider, store: store.clone(), chunk_options, batch_size: batch_size.max(1) };
+        tokio::spawn(worker.run(rx));
+        info!("Semantic embedding worker started (queue capacity {})", capacity.max(1));
+        Self { tx, store }
+    }
+
+    /// Enqueue a file for embedding.
+    ///
+    /// Awaits queue capacity when full (strict backpressure). Errors only if the
+    /// worker has stopped (channel closed) — the caller logs and continues, as
+    /// the Tantivy index remains the source of truth.
+    pub async fn index_file(&self, job: IndexJob) -> Result<()> {
+        self.tx.send(job).await.map_err(|_| anyhow!("Semantic embedding worker is no longer running"))
+    }
+
+    /// Delete all chunks of a repository.
+    ///
+    /// Runs directly against the store (not via the queue) so a delete issued
+    /// before a re-crawl is applied before the re-crawl's inserts, matching the
+    /// crawler's "delete then re-index" ordering for Tantivy.
+    pub async fn delete_project(&self, repository: &str) -> Result<u64> {
+        self.store.delete_project_chunks(repository).await
+    }
+
+    /// Current number of stored chunks (for logging / admin card).
+    pub async fn count(&self) -> Result<u64> {
+        self.store.count().await
+    }
+}
+
+struct Worker {
+    provider: Arc<dyn EmbeddingProvider>,
+    store: Arc<dyn VectorStore>,
+    chunk_options: ChunkOptions,
+    batch_size: usize,
+}
+
+impl Worker {
+    async fn run(self, mut rx: mpsc::Receiver<IndexJob>) {
+        while let Some(job) = rx.recv().await {
+            let file_id = job.file_id;
+            if let Err(e) = self.process(job).await {
+                // One bad file must never kill the worker: log and keep draining.
+                error!("Semantic indexing failed for file_id={file_id}: {e}");
+            }
+        }
+        info!("Semantic embedding worker stopped (queue drained)");
+    }
+
+    async fn process(&self, job: IndexJob) -> Result<()> {
+        let chunks = chunk_file(&job.path, &job.content, &self.chunk_options);
+        if chunks.is_empty() {
+            // Empty file: still upsert (with no records) so a file that became
+            // empty has its old chunks removed.
+            return self.store.upsert_file_chunks(job.file_id, Vec::new()).await;
+        }
+
+        let mut records: Vec<ChunkRecord> = Vec::with_capacity(chunks.len());
+        for batch in chunks.chunks(self.batch_size) {
+            let texts: Vec<String> = batch.iter().map(|c| c.text.clone()).collect();
+            // Embedding is CPU-bound and synchronous; keep it off the async runtime.
+            let provider = self.provider.clone();
+            let vectors = tokio::task::spawn_blocking(move || provider.embed(&texts))
+                .await
+                .map_err(|e| anyhow!("embedding task panicked: {e}"))??;
+
+            if vectors.len() != batch.len() {
+                return Err(anyhow!(
+                    "embedder returned {} vectors for {} chunks",
+                    vectors.len(),
+                    batch.len()
+                ));
+            }
+
+            for (chunk, vector) in batch.iter().zip(vectors) {
+                // Metadata is identical for every chunk of a file; the per-field
+                // clone here is one String alloc per chunk (unavoidable while
+                // ChunkRecord owns its strings), not per batch field × chunk.
+                records.push(ChunkRecord {
+                    file_id: job.file_id,
+                    repository: job.repository.clone(),
+                    project: job.project.clone(),
+                    version: job.version.clone(),
+                    path: job.path.clone(),
+                    extension: job.extension.clone(),
+                    start_line: chunk.start_line as u32,
+                    end_line: chunk.end_line as u32,
+                    vector,
+                });
+            }
+        }
+
+        let n = records.len();
+        self.store.upsert_file_chunks(job.file_id, records).await?;
+        debug!("Embedded {n} chunks for {} (file_id={})", job.path, job.file_id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::semantic::store::LanceVectorStore;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const DIM: usize = 8;
+
+    /// Deterministic, ONNX-free provider so worker tests run in normal CI
+    /// without downloading a model.
+    struct MockProvider {
+        calls: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    impl EmbeddingProvider for MockProvider {
+        fn dimension(&self) -> usize {
+            DIM
+        }
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+        fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                return Err(anyhow!("mock embed failure"));
+            }
+            // A trivial but input-dependent vector so identical texts map alike.
+            Ok(texts
+                .iter()
+                .map(|t| {
+                    let seed = (t.len() % 7) as f32;
+                    vec![seed; DIM]
+                })
+                .collect())
+        }
+    }
+
+    async fn store(dir: &tempfile::TempDir) -> Arc<dyn VectorStore> {
+        Arc::new(LanceVectorStore::open(dir.path(), DIM).await.unwrap())
+    }
+
+    fn job(content: &str) -> IndexJob {
+        IndexJob {
+            file_id: Uuid::new_v4(),
+            repository: "repo".to_string(),
+            project: "repo".to_string(),
+            version: "main".to_string(),
+            path: "src/lib.rs".to_string(),
+            extension: "rs".to_string(),
+            content: content.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_indexes_a_file_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let indexer = VectorIndexer::start(
+            Arc::new(MockProvider { calls: calls.clone(), fail: false }),
+            store.clone(),
+            ChunkOptions::default(),
+            32,
+            16,
+        );
+
+        indexer.index_file(job("fn main() {\n    println!(\"hi\");\n}")).await.unwrap();
+        // Drop the indexer to close the channel and let the worker drain+finish.
+        drop(indexer);
+        // The store reflects the work once the worker has processed it.
+        wait_until(|| store.count(), 1).await;
+        assert!(calls.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_reindex_same_file_no_duplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let indexer = VectorIndexer::start(
+            Arc::new(MockProvider { calls: Arc::new(AtomicUsize::new(0)), fail: false }),
+            store.clone(),
+            ChunkOptions::default(),
+            32,
+            16,
+        );
+        let mut j = job("fn a() {}");
+        indexer.index_file(j.clone()).await.unwrap();
+        wait_until(|| store.count(), 1).await;
+        // Same file_id, new content → replaces, not appends.
+        j.content = "fn b() {}\nfn c() {}".to_string();
+        indexer.index_file(j).await.unwrap();
+        // Still a single chunk for a tiny file → count stays 1.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(store.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_bad_file_does_not_kill_worker() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let indexer = VectorIndexer::start(
+            Arc::new(MockProvider { calls: Arc::new(AtomicUsize::new(0)), fail: true }),
+            store.clone(),
+            ChunkOptions::default(),
+            32,
+            16,
+        );
+        // Failing embed: worker logs and continues; nothing stored, no panic.
+        indexer.index_file(job("fn a() {}")).await.unwrap();
+        indexer.index_file(job("fn b() {}")).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(store.count().await.unwrap(), 0);
+        // Worker still alive: enqueue succeeds.
+        assert!(indexer.index_file(job("fn c() {}")).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_project_passthrough() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let indexer = VectorIndexer::start(
+            Arc::new(MockProvider { calls: Arc::new(AtomicUsize::new(0)), fail: false }),
+            store.clone(),
+            ChunkOptions::default(),
+            32,
+            16,
+        );
+        indexer.index_file(job("fn a() {}")).await.unwrap();
+        wait_until(|| store.count(), 1).await;
+        assert_eq!(indexer.delete_project("repo").await.unwrap(), 1);
+        assert_eq!(store.count().await.unwrap(), 0);
+    }
+
+    /// Poll an async count fn until it reaches `target` (bounded), so tests
+    /// don't race the background worker.
+    async fn wait_until<F, Fut>(mut f: F, target: u64)
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<u64>>,
+    {
+        for _ in 0..50 {
+            if f().await.unwrap() >= target {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("count did not reach {target} in time");
+    }
+}

--- a/klask-rs/src/services/semantic/mod.rs
+++ b/klask-rs/src/services/semantic/mod.rs
@@ -11,13 +11,37 @@
 pub mod chunker;
 pub mod embedder;
 pub mod fusion;
+#[cfg(feature = "semantic-search")]
+pub mod indexer;
+#[cfg(feature = "semantic-search")]
+pub mod store;
 
 pub use embedder::EmbeddingProvider;
 #[cfg(feature = "semantic-search")]
 pub use embedder::FastEmbedProvider;
+#[cfg(feature = "semantic-search")]
+pub use indexer::{IndexJob, VectorIndexer};
 
 use crate::config::SemanticSearchConfig;
 use std::sync::Arc;
+
+/// Zero-sized indexer placeholder for builds without the `semantic-search`
+/// feature. Deliberately `Clone` but **not** `Copy` so that the `.clone()`
+/// calls threading [`MaybeIndexer`] through the crawler compile identically in
+/// both build modes (a `Copy` type would make those clones a clippy warning).
+#[cfg(not(feature = "semantic-search"))]
+#[derive(Clone)]
+pub struct DisabledIndexer;
+
+/// Optional handle to the embedding worker, carried by `AppState` and the
+/// crawler. Resolves to `Option<Arc<VectorIndexer>>` with the feature and to a
+/// zero-sized always-`None` type without it, so call sites stay feature-agnostic
+/// (no `#[cfg]` at every struct field / constructor) and the no-feature build
+/// pays nothing.
+#[cfg(feature = "semantic-search")]
+pub type MaybeIndexer = Option<Arc<VectorIndexer>>;
+#[cfg(not(feature = "semantic-search"))]
+pub type MaybeIndexer = Option<DisabledIndexer>;
 
 /// Initialize the embedding provider from configuration.
 ///
@@ -75,6 +99,59 @@ pub fn init_embedding_provider(config: &SemanticSearchConfig) -> Option<Arc<dyn 
     }
 }
 
+/// Open the vector store and start the background embedding worker.
+///
+/// Returns `None` (degrading to keyword-only indexing) when semantic search is
+/// off, the feature is not compiled in, or the store fails to open — the server
+/// keeps crawling and serving keyword search instead of refusing to start.
+/// Requires the embedding `provider` produced by [`init_embedding_provider`].
+#[cfg(feature = "semantic-search")]
+pub async fn init_vector_indexer(
+    config: &SemanticSearchConfig,
+    provider: Arc<dyn EmbeddingProvider>,
+) -> Option<Arc<VectorIndexer>> {
+    use chunker::ChunkOptions;
+    use store::LanceVectorStore;
+
+    // These are clamped to >=1 by VectorIndexer::start, but a zero value almost
+    // certainly means a misconfiguration — surface it rather than silently
+    // running inference one chunk at a time / with a length-1 queue.
+    if config.batch_size == 0 {
+        tracing::warn!("SEMANTIC_SEARCH_BATCH_SIZE is 0; using 1 (this cripples embedding throughput)");
+    }
+    if config.queue_capacity == 0 {
+        tracing::warn!("SEMANTIC_SEARCH_QUEUE_CAPACITY is 0; using 1");
+    }
+
+    let dimension = provider.dimension();
+    let store = match LanceVectorStore::open(&config.vector_store_dir, dimension).await {
+        Ok(store) => Arc::new(store),
+        Err(e) => {
+            tracing::error!(
+                "Failed to open vector store at '{}', semantic indexing disabled: {e}",
+                config.vector_store_dir
+            );
+            return None;
+        }
+    };
+
+    let chunk_options = ChunkOptions { max_lines: config.chunk_max_lines, overlap_lines: config.chunk_overlap_lines };
+
+    let indexer = VectorIndexer::start(provider, store, chunk_options, config.batch_size, config.queue_capacity);
+
+    match indexer.count().await {
+        Ok(n) => tracing::info!(
+            "Vector store ready at '{}' ({} chunks, dimension {})",
+            config.vector_store_dir,
+            n,
+            dimension
+        ),
+        Err(e) => tracing::warn!("Vector store opened but count() failed: {e}"),
+    }
+
+    Some(Arc::new(indexer))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,9 +161,11 @@ mod tests {
             enabled: false,
             model: "jinaai/jina-embeddings-v2-base-code".to_string(),
             cache_dir: "./models".to_string(),
+            vector_store_dir: "./vector-index".to_string(),
             chunk_max_lines: 60,
             chunk_overlap_lines: 15,
             batch_size: 32,
+            queue_capacity: 1000,
         }
     }
 

--- a/klask-rs/src/services/semantic/store.rs
+++ b/klask-rs/src/services/semantic/store.rs
@@ -1,0 +1,432 @@
+//! Persistent vector store for semantic search (LanceDB).
+//!
+//! Stores one row per code chunk: the embedding vector plus the metadata
+//! columns needed to filter (mirroring Tantivy facets) and to render a snippet
+//! (`path`, `start_line`, `end_line`). The store is embedded — it persists to a
+//! local directory next to the Tantivy index, so Klask stays a single binary
+//! plus volumes (see docs/SEMANTIC_SEARCH_PLAN.md §3.2).
+//!
+//! The whole module is gated on the `semantic-search` feature; without it the
+//! binary pulls neither LanceDB nor Arrow. The query path (ANN search, RRF
+//! wiring) lands in plan phase 4 — phase 2 is the write/lifecycle path only,
+//! so no ANN index is created here yet.
+#![cfg(feature = "semantic-search")]
+
+use anyhow::Result;
+use uuid::Uuid;
+
+/// One embedded code chunk ready to persist.
+///
+/// Field semantics mirror `search::FileData` so the two indexes describe the
+/// same universe and filters behave identically across engines.
+#[derive(Debug, Clone)]
+pub struct ChunkRecord {
+    pub file_id: Uuid,
+    /// Parent repository (mass-deletion + facet key), mirrors Tantivy `repository`.
+    pub repository: String,
+    /// Individual project name (facet), mirrors Tantivy `project`.
+    pub project: String,
+    /// Branch/version (facet).
+    pub version: String,
+    /// File path relative to the repo root (for snippet display).
+    pub path: String,
+    /// File extension (facet).
+    pub extension: String,
+    /// First line of the chunk, 1-based inclusive.
+    pub start_line: u32,
+    /// Last line of the chunk, 1-based inclusive.
+    pub end_line: u32,
+    /// Embedding vector; length must equal the store's configured dimension.
+    pub vector: Vec<f32>,
+}
+
+/// Persistent vector store abstraction.
+///
+/// A trait (like [`super::EmbeddingProvider`]) so the indexer and future query
+/// path depend on behaviour, not on LanceDB directly — which keeps tests able
+/// to swap in an in-memory fake and lets the backend change later.
+#[async_trait::async_trait]
+pub trait VectorStore: Send + Sync {
+    /// Replace all chunks of `file_id` with `records` (delete-then-insert),
+    /// mirroring Tantivy's `upsert_file`. `records` may be empty (just deletes).
+    /// Every record's `vector` must have length [`VectorStore::dimension`].
+    async fn upsert_file_chunks(&self, file_id: Uuid, records: Vec<ChunkRecord>) -> Result<()>;
+
+    /// Delete all chunks of a single file. Returns the number of rows removed.
+    /// Part of the lifecycle API for per-file removal (a file deleted from a
+    /// repo between crawls); the incremental-delete wiring lands in a later
+    /// phase, so it is currently exercised only by tests.
+    #[allow(dead_code)]
+    async fn delete_file(&self, file_id: Uuid) -> Result<u64>;
+
+    /// Delete all chunks of a repository (mirrors `delete_project_documents`).
+    /// Returns the number of rows removed.
+    async fn delete_project_chunks(&self, repository: &str) -> Result<u64>;
+
+    /// Total number of stored chunks (for the admin index card, phases 3/5).
+    async fn count(&self) -> Result<u64>;
+
+    /// Embedding dimension the store was opened with. Used by tests and the
+    /// query path (phase 4); kept on the trait for backend swappability.
+    #[allow(dead_code)]
+    fn dimension(&self) -> usize;
+}
+
+/// Escape a string for safe inclusion as a single-quoted SQL literal in a
+/// LanceDB filter predicate.
+///
+/// LanceDB's `delete` takes a raw SQL predicate string, so user-controlled
+/// values (repository names) must be escaped to avoid predicate injection.
+/// SQL escapes a single quote by doubling it.
+pub(crate) fn sql_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+pub use lance_store::LanceVectorStore;
+
+mod lance_store {
+    use super::{ChunkRecord, VectorStore, sql_quote};
+    use anyhow::{Context, Result, anyhow};
+    use arrow_array::{
+        Array, FixedSizeListArray, RecordBatch, StringArray, UInt32Array,
+        builder::{FixedSizeListBuilder, Float32Builder},
+    };
+    use arrow_schema::{DataType, Field, Schema, SchemaRef};
+    use lancedb::{Connection, Table, connect};
+    use std::path::Path;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    const TABLE_NAME: &str = "chunks";
+
+    /// LanceDB-backed [`VectorStore`].
+    pub struct LanceVectorStore {
+        #[allow(dead_code)] // kept alive for the table; future phases reopen tables
+        connection: Connection,
+        table: Table,
+        schema: SchemaRef,
+        dimension: usize,
+    }
+
+    /// Build the Arrow schema for the chunks table at a given vector dimension.
+    fn chunks_schema(dimension: usize) -> SchemaRef {
+        let vector_field = Field::new(
+            "vector",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dimension as i32),
+            true,
+        );
+        Arc::new(Schema::new(vec![
+            Field::new("chunk_id", DataType::Utf8, false),
+            Field::new("file_id", DataType::Utf8, false),
+            Field::new("repository", DataType::Utf8, false),
+            Field::new("project", DataType::Utf8, false),
+            Field::new("version", DataType::Utf8, false),
+            Field::new("path", DataType::Utf8, false),
+            Field::new("extension", DataType::Utf8, false),
+            Field::new("start_line", DataType::UInt32, false),
+            Field::new("end_line", DataType::UInt32, false),
+            vector_field,
+        ]))
+    }
+
+    /// Extract the vector dimension from an existing table's schema, if present.
+    fn schema_dimension(schema: &Schema) -> Option<usize> {
+        schema.field_with_name("vector").ok().and_then(|f| match f.data_type() {
+            DataType::FixedSizeList(_, len) => Some(*len as usize),
+            _ => None,
+        })
+    }
+
+    impl LanceVectorStore {
+        /// Open (creating on first use) the chunks table under `path`.
+        ///
+        /// If a table already exists with a different vector dimension than
+        /// `dimension` (e.g. the embedding model changed), opening fails with a
+        /// clear error rather than silently corrupting the index — the operator
+        /// must rebuild it. This mirrors the strict model resolution in
+        /// `embedder::resolve_model`.
+        pub async fn open(path: impl AsRef<Path>, dimension: usize) -> Result<Self> {
+            if dimension == 0 {
+                return Err(anyhow!("Vector store dimension must be non-zero"));
+            }
+            let uri = path.as_ref().to_string_lossy().to_string();
+            let connection =
+                connect(&uri).execute().await.with_context(|| format!("Failed to open LanceDB at '{uri}'"))?;
+
+            let schema = chunks_schema(dimension);
+
+            let existing = connection.table_names().execute().await.context("Failed to list LanceDB tables")?;
+
+            let table = if existing.iter().any(|n| n == TABLE_NAME) {
+                let table = connection.open_table(TABLE_NAME).execute().await.context("Failed to open chunks table")?;
+                let existing_schema = table.schema().await.context("Failed to read chunks table schema")?;
+                match schema_dimension(&existing_schema) {
+                    Some(existing_dim) if existing_dim != dimension => {
+                        return Err(anyhow!(
+                            "Vector store at '{uri}' was built with dimension {existing_dim}, but the configured \
+                             embedding model produces dimension {dimension}. The embedding model changed; rebuild \
+                             the semantic index (delete '{uri}') before continuing."
+                        ));
+                    }
+                    Some(_) => table,
+                    None => {
+                        return Err(anyhow!(
+                            "Existing LanceDB table '{TABLE_NAME}' at '{uri}' has no recognizable vector column"
+                        ));
+                    }
+                }
+            } else {
+                connection
+                    .create_empty_table(TABLE_NAME, schema.clone())
+                    .execute()
+                    .await
+                    .context("Failed to create chunks table")?
+            };
+
+            Ok(Self { connection, table, schema, dimension })
+        }
+
+        /// Convert chunk records into a single Arrow `RecordBatch`.
+        fn records_to_batch(&self, records: &[ChunkRecord]) -> Result<RecordBatch> {
+            let mut chunk_id = Vec::with_capacity(records.len());
+            let mut file_id = Vec::with_capacity(records.len());
+            let mut repository = Vec::with_capacity(records.len());
+            let mut project = Vec::with_capacity(records.len());
+            let mut version = Vec::with_capacity(records.len());
+            let mut path = Vec::with_capacity(records.len());
+            let mut extension = Vec::with_capacity(records.len());
+            let mut start_line = Vec::with_capacity(records.len());
+            let mut end_line = Vec::with_capacity(records.len());
+
+            let mut vector_builder = FixedSizeListBuilder::new(
+                Float32Builder::with_capacity(records.len() * self.dimension),
+                self.dimension as i32,
+            );
+
+            for record in records {
+                if record.vector.len() != self.dimension {
+                    return Err(anyhow!(
+                        "Chunk vector length {} does not match store dimension {}",
+                        record.vector.len(),
+                        self.dimension
+                    ));
+                }
+                // chunk_id is deterministic so a re-index of the same file produces the
+                // same row identity; file_id delete-then-insert keeps it dedup-correct.
+                chunk_id.push(format!("{}:{}", record.file_id, record.start_line));
+                file_id.push(record.file_id.to_string());
+                repository.push(record.repository.clone());
+                project.push(record.project.clone());
+                version.push(record.version.clone());
+                path.push(record.path.clone());
+                extension.push(record.extension.clone());
+                start_line.push(record.start_line);
+                end_line.push(record.end_line);
+
+                vector_builder.values().append_slice(&record.vector);
+                vector_builder.append(true);
+            }
+
+            let vector: FixedSizeListArray = vector_builder.finish();
+
+            RecordBatch::try_new(
+                self.schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(chunk_id)),
+                    Arc::new(StringArray::from(file_id)),
+                    Arc::new(StringArray::from(repository)),
+                    Arc::new(StringArray::from(project)),
+                    Arc::new(StringArray::from(version)),
+                    Arc::new(StringArray::from(path)),
+                    Arc::new(StringArray::from(extension)),
+                    Arc::new(UInt32Array::from(start_line)),
+                    Arc::new(UInt32Array::from(end_line)),
+                    Arc::new(vector) as Arc<dyn Array>,
+                ],
+            )
+            .context("Failed to build Arrow RecordBatch for chunks")
+        }
+
+        async fn delete_where(&self, predicate: &str) -> Result<u64> {
+            let result =
+                self.table.delete(predicate).await.with_context(|| format!("LanceDB delete failed: {predicate}"))?;
+            Ok(result.num_deleted_rows)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl VectorStore for LanceVectorStore {
+        async fn upsert_file_chunks(&self, file_id: Uuid, records: Vec<ChunkRecord>) -> Result<()> {
+            // Delete-then-insert: remove any prior chunks of this file first so a
+            // re-index never leaves stale rows behind (mirrors Tantivy upsert_file).
+            self.delete_where(&format!("file_id = {}", sql_quote(&file_id.to_string()))).await?;
+
+            if records.is_empty() {
+                return Ok(());
+            }
+            let batch = self.records_to_batch(&records)?;
+            self.table.add(batch).execute().await.context("Failed to add chunk vectors to LanceDB")?;
+            Ok(())
+        }
+
+        async fn delete_file(&self, file_id: Uuid) -> Result<u64> {
+            self.delete_where(&format!("file_id = {}", sql_quote(&file_id.to_string()))).await
+        }
+
+        async fn delete_project_chunks(&self, repository: &str) -> Result<u64> {
+            self.delete_where(&format!("repository = {}", sql_quote(repository))).await
+        }
+
+        async fn count(&self) -> Result<u64> {
+            let n = self.table.count_rows(None).await.context("Failed to count LanceDB rows")?;
+            Ok(n as u64)
+        }
+
+        fn dimension(&self) -> usize {
+            self.dimension
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn record(file_id: Uuid, repository: &str, start: u32, dim: usize) -> ChunkRecord {
+            ChunkRecord {
+                file_id,
+                repository: repository.to_string(),
+                project: repository.to_string(),
+                version: "main".to_string(),
+                path: "src/lib.rs".to_string(),
+                extension: "rs".to_string(),
+                start_line: start,
+                end_line: start + 5,
+                vector: vec![0.1_f32; dim],
+            }
+        }
+
+        async fn temp_store(dim: usize) -> (tempfile::TempDir, LanceVectorStore) {
+            let dir = tempfile::tempdir().unwrap();
+            let store = LanceVectorStore::open(dir.path(), dim).await.unwrap();
+            (dir, store)
+        }
+
+        #[tokio::test]
+        async fn test_open_creates_empty_table() {
+            let (_dir, store) = temp_store(8).await;
+            assert_eq!(store.dimension(), 8);
+            assert_eq!(store.count().await.unwrap(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_upsert_and_count() {
+            let (_dir, store) = temp_store(8).await;
+            let fid = Uuid::new_v4();
+            store
+                .upsert_file_chunks(fid, vec![record(fid, "repo-a", 1, 8), record(fid, "repo-a", 7, 8)])
+                .await
+                .unwrap();
+            assert_eq!(store.count().await.unwrap(), 2);
+        }
+
+        #[tokio::test]
+        async fn test_upsert_same_file_replaces_no_duplicates() {
+            let (_dir, store) = temp_store(8).await;
+            let fid = Uuid::new_v4();
+            store
+                .upsert_file_chunks(fid, vec![record(fid, "repo-a", 1, 8), record(fid, "repo-a", 7, 8)])
+                .await
+                .unwrap();
+            // Re-index the same file with a single chunk: old rows must be gone.
+            store.upsert_file_chunks(fid, vec![record(fid, "repo-a", 1, 8)]).await.unwrap();
+            assert_eq!(store.count().await.unwrap(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_upsert_empty_only_deletes() {
+            let (_dir, store) = temp_store(8).await;
+            let fid = Uuid::new_v4();
+            store.upsert_file_chunks(fid, vec![record(fid, "repo-a", 1, 8)]).await.unwrap();
+            store.upsert_file_chunks(fid, vec![]).await.unwrap();
+            assert_eq!(store.count().await.unwrap(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_delete_file_only_removes_that_file() {
+            let (_dir, store) = temp_store(8).await;
+            let a = Uuid::new_v4();
+            let b = Uuid::new_v4();
+            store.upsert_file_chunks(a, vec![record(a, "repo-a", 1, 8)]).await.unwrap();
+            store.upsert_file_chunks(b, vec![record(b, "repo-a", 1, 8)]).await.unwrap();
+            assert_eq!(store.delete_file(a).await.unwrap(), 1);
+            assert_eq!(store.count().await.unwrap(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_delete_project_only_removes_that_repo() {
+            let (_dir, store) = temp_store(8).await;
+            let a = Uuid::new_v4();
+            let b = Uuid::new_v4();
+            store.upsert_file_chunks(a, vec![record(a, "repo-a", 1, 8)]).await.unwrap();
+            store.upsert_file_chunks(b, vec![record(b, "repo-b", 1, 8)]).await.unwrap();
+            assert_eq!(store.delete_project_chunks("repo-a").await.unwrap(), 1);
+            assert_eq!(store.count().await.unwrap(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_dimension_mismatch_on_reopen_errors() {
+            let dir = tempfile::tempdir().unwrap();
+            {
+                let store = LanceVectorStore::open(dir.path(), 8).await.unwrap();
+                let fid = Uuid::new_v4();
+                store.upsert_file_chunks(fid, vec![record(fid, "repo-a", 1, 8)]).await.unwrap();
+            }
+            // `unwrap_err` would require the Ok type to be `Debug`, which the
+            // LanceDB-backed store is not; match the error out explicitly.
+            let err = match LanceVectorStore::open(dir.path(), 16).await {
+                Ok(_) => panic!("opening with a mismatched dimension must fail"),
+                Err(e) => e.to_string(),
+            };
+            assert!(
+                err.contains("dimension 8"),
+                "error should mention the existing dimension: {err}"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_wrong_vector_length_rejected() {
+            let (_dir, store) = temp_store(8).await;
+            let fid = Uuid::new_v4();
+            let mut rec = record(fid, "repo-a", 1, 8);
+            rec.vector = vec![0.0; 4]; // wrong length
+            assert!(store.upsert_file_chunks(fid, vec![rec]).await.is_err());
+        }
+
+        #[tokio::test]
+        async fn test_repository_name_with_quote_is_safe() {
+            // A repository name containing a single quote must not break the
+            // delete predicate (injection guard).
+            let (_dir, store) = temp_store(8).await;
+            let fid = Uuid::new_v4();
+            let nasty = "repo' OR '1'='1";
+            store.upsert_file_chunks(fid, vec![record(fid, nasty, 1, 8)]).await.unwrap();
+            // Deleting a different repo must remove nothing despite the quote.
+            assert_eq!(store.delete_project_chunks("other").await.unwrap(), 0);
+            assert_eq!(store.count().await.unwrap(), 1);
+            // Deleting the real (quoted) name removes exactly its row.
+            assert_eq!(store.delete_project_chunks(nasty).await.unwrap(), 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sql_quote_escapes_single_quotes() {
+        assert_eq!(sql_quote("repo"), "'repo'");
+        assert_eq!(sql_quote("a'b"), "'a''b'");
+        assert_eq!(sql_quote("' OR '1'='1"), "''' OR ''1''=''1'");
+    }
+}

--- a/klask-rs/tests/admin_endpoints_test.rs
+++ b/klask-rs/tests/admin_endpoints_test.rs
@@ -42,6 +42,7 @@ async fn setup_test_server() -> Result<(TestServer, AppState)> {
             progress_tracker.clone(),
             encryption_service,
             std::env::temp_dir().join("klask-crawler-test").to_string_lossy().to_string(),
+            None,
         )
         .expect("Failed to create crawler service"),
     );
@@ -53,6 +54,7 @@ async fn setup_test_server() -> Result<(TestServer, AppState)> {
         progress_tracker,
         scheduler_service: None,
         semantic_embedder: None,
+        semantic_indexer: None,
         jwt_service,
         config,
         crawl_tasks: Arc::new(RwLock::new(HashMap::new())),

--- a/klask-rs/tests/auth_test.rs
+++ b/klask-rs/tests/auth_test.rs
@@ -47,9 +47,11 @@ async fn create_test_app_state() -> AppState {
             enabled: false,
             model: "jinaai/jina-embeddings-v2-base-code".to_string(),
             cache_dir: "./models".to_string(),
+            vector_store_dir: "./vector-index".to_string(),
             chunk_max_lines: 60,
             chunk_overlap_lines: 15,
             batch_size: 32,
+            queue_capacity: 1000,
         },
     };
 
@@ -73,6 +75,7 @@ async fn create_test_app_state() -> AppState {
             progress_tracker.clone(),
             encryption_service,
             std::env::temp_dir().join("klask-crawler-test").to_string_lossy().to_string(),
+            None,
         )
         .expect("Failed to create crawler service"),
     );
@@ -84,6 +87,7 @@ async fn create_test_app_state() -> AppState {
         progress_tracker,
         scheduler_service: None,
         semantic_embedder: None,
+        semantic_indexer: None,
         jwt_service,
         config,
         crawl_tasks: Arc::new(RwLock::new(HashMap::new())),
@@ -285,9 +289,11 @@ async fn create_test_app_state_with_registration(allow_registration: bool) -> Ap
             enabled: false,
             model: "jinaai/jina-embeddings-v2-base-code".to_string(),
             cache_dir: "./models".to_string(),
+            vector_store_dir: "./vector-index".to_string(),
             chunk_max_lines: 60,
             chunk_overlap_lines: 15,
             batch_size: 32,
+            queue_capacity: 1000,
         },
     };
 
@@ -311,6 +317,7 @@ async fn create_test_app_state_with_registration(allow_registration: bool) -> Ap
             progress_tracker.clone(),
             encryption_service.clone(),
             std::env::temp_dir().join("klask-crawler-test").to_string_lossy().to_string(),
+            None,
         )
         .expect("Failed to create crawler service"),
     );
@@ -322,6 +329,7 @@ async fn create_test_app_state_with_registration(allow_registration: bool) -> Ap
         progress_tracker,
         scheduler_service: None,
         semantic_embedder: None,
+        semantic_indexer: None,
         jwt_service,
         config,
         crawl_tasks: Arc::new(RwLock::new(HashMap::new())),

--- a/klask-rs/tests/semantic_embedding_test.rs
+++ b/klask-rs/tests/semantic_embedding_test.rs
@@ -19,9 +19,11 @@ fn test_config() -> SemanticSearchConfig {
         enabled: true,
         model: "Xenova/bge-small-en-v1.5".to_string(),
         cache_dir: "target/fastembed-cache".to_string(),
+        vector_store_dir: "target/vector-index".to_string(),
         chunk_max_lines: 60,
         chunk_overlap_lines: 15,
         batch_size: 32,
+        queue_capacity: 1000,
     }
 }
 

--- a/klask-rs/tests/semantic_indexing_test.rs
+++ b/klask-rs/tests/semantic_indexing_test.rs
@@ -1,0 +1,127 @@
+//! Integration test for the semantic indexing write path (Phase 2):
+//! real embedding model → real LanceDB store, exercised through the
+//! [`VectorIndexer`] worker exactly as the crawler drives it.
+//!
+//! Loads a real ONNX model (downloaded on first run into target/fastembed-cache)
+//! and writes a real LanceDB index, so it is `#[ignore]`d by default:
+//!
+//! ```bash
+//! cargo test --features semantic-search --test semantic_indexing_test -- --ignored --nocapture
+//! ```
+#![cfg(feature = "semantic-search")]
+
+use klask_rs::config::SemanticSearchConfig;
+use klask_rs::services::semantic::chunker::ChunkOptions;
+use klask_rs::services::semantic::embedder::{EmbeddingProvider, FastEmbedProvider};
+use klask_rs::services::semantic::store::LanceVectorStore;
+use klask_rs::services::semantic::{IndexJob, VectorIndexer};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Small model (384 dims) to keep the download reasonable.
+fn test_config(cache_dir: &str, vector_dir: &str) -> SemanticSearchConfig {
+    SemanticSearchConfig {
+        enabled: true,
+        model: "Xenova/bge-small-en-v1.5".to_string(),
+        cache_dir: cache_dir.to_string(),
+        vector_store_dir: vector_dir.to_string(),
+        chunk_max_lines: 60,
+        chunk_overlap_lines: 15,
+        batch_size: 32,
+        queue_capacity: 64,
+    }
+}
+
+fn job(file_id: Uuid, repository: &str, path: &str, content: &str) -> IndexJob {
+    IndexJob {
+        file_id,
+        repository: repository.to_string(),
+        project: repository.to_string(),
+        version: "main".to_string(),
+        path: path.to_string(),
+        extension: "rs".to_string(),
+        content: content.to_string(),
+    }
+}
+
+async fn count_eventually(indexer: &VectorIndexer, target: u64) -> u64 {
+    for _ in 0..100 {
+        let n = indexer.count().await.unwrap();
+        if n >= target {
+            return n;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    indexer.count().await.unwrap()
+}
+
+#[tokio::test]
+#[ignore = "requires downloading an ONNX model and writing a real LanceDB index"]
+async fn test_full_indexing_lifecycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let vector_dir = tmp.path().join("vector-index");
+    let config = test_config("target/fastembed-cache", vector_dir.to_str().unwrap());
+
+    let provider = Arc::new(FastEmbedProvider::try_new(&config).expect("load embedding model"));
+    let store = Arc::new(LanceVectorStore::open(&config.vector_store_dir, provider.dimension()).await.unwrap());
+
+    let indexer = VectorIndexer::start(
+        provider.clone(),
+        store.clone(),
+        ChunkOptions { max_lines: config.chunk_max_lines, overlap_lines: config.chunk_overlap_lines },
+        config.batch_size,
+        config.queue_capacity,
+    );
+
+    let f1 = Uuid::new_v4();
+    let f2 = Uuid::new_v4();
+
+    // 1. Index two files in two repositories.
+    indexer
+        .index_file(job(
+            f1,
+            "repo-a",
+            "src/auth.rs",
+            "fn validate_jwt(token: &str) -> bool {\n    !token.is_empty()\n}",
+        ))
+        .await
+        .unwrap();
+    indexer
+        .index_file(job(
+            f2,
+            "repo-b",
+            "src/main.rs",
+            "fn main() {\n    println!(\"hello\");\n}",
+        ))
+        .await
+        .unwrap();
+
+    let after_index = count_eventually(&indexer, 2).await;
+    assert!(
+        after_index >= 2,
+        "both files should produce at least one chunk each, got {after_index}"
+    );
+
+    // 2. Re-index f1 with new content: chunks replaced, not duplicated.
+    indexer.index_file(job(f1, "repo-a", "src/auth.rs", "fn validate_jwt() {}")).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    let after_reindex = indexer.count().await.unwrap();
+    assert_eq!(
+        after_reindex, after_index,
+        "re-indexing the same file must not add duplicate rows"
+    );
+
+    // 3. Delete repo-a: only repo-b's chunks remain.
+    let deleted = indexer.delete_project("repo-a").await.unwrap();
+    assert!(deleted >= 1, "delete_project should remove repo-a's chunks");
+    let remaining = indexer.count().await.unwrap();
+    assert!(remaining >= 1, "repo-b chunks should remain after deleting repo-a");
+
+    // 4. Delete repo-b: store is empty.
+    indexer.delete_project("repo-b").await.unwrap();
+    assert_eq!(
+        indexer.count().await.unwrap(),
+        0,
+        "store should be empty after deleting all repos"
+    );
+}


### PR DESCRIPTION
## Phase 2 of hybrid semantic search

Builds on Phase 1 (#120). This PR is **stacked on `semantic-search`**, so the diff shows only Phase 2; merge #120 first.

Adds the persistent **vector store** and the **write/lifecycle path** that keeps it consistent with the Tantivy index. Still fully self-hosted, behind the opt-in `semantic-search` cargo feature — zero overhead and no behavioural change when disabled.

### What's included
- **`LanceVectorStore`** (`lancedb`, embedded): `chunks` table mirroring Tantivy facets + a `FixedSizeList<Float32, dim>` vector column, persisted under `SEMANTIC_SEARCH_VECTOR_DIR` (default `./vector-index`). Delete-then-insert upsert, delete-by-file, delete-by-project, count. Reopening with a different embedding dimension (model change) is **refused** with a clear error to prevent silent corruption. Delete predicates are SQL-escaped (`sql_quote`).
- **`VectorIndexer`**: a single background worker fed by a **bounded** queue that chunks → embeds (`spawn_blocking`) → upserts. **Strict backpressure** — the crawl blocks when the queue is full, so chunks are never silently dropped and the vector index stays consistent with the crawl. A failed file is logged and skipped without killing the worker; graceful drain on shutdown.
- **Crawl integration**: each upserted file is mirrored into the vector store, and the delete lifecycle is mirrored at every site that clears the Tantivy index (re-crawl for Git/GitLab/GitHub + the two repository-deletion endpoints).
- **Config**: `SEMANTIC_SEARCH_VECTOR_DIR`, `SEMANTIC_SEARCH_QUEUE_CAPACITY` (+ `.env.example`), with graceful degradation to keyword-only indexing if the store can't open.

### Scope
Write/storage path only. The query path (`mode` param, RRF wiring, API) is **Phase 4**; the backfill admin job is **Phase 3** — both intentionally out of scope here.

### Testing
- `cargo test` (no feature): full suite passes (247 lib + all integration).
- `cargo test --features semantic-search`: 32 semantic tests pass (store, worker incl. dedup / injection-guard / dimension-mismatch).
- Ignored real-model end-to-end lifecycle test passes (real ONNX → real LanceDB → index, re-index no-dup, delete-by-project, empty):
  `cargo test --features semantic-search --test semantic_indexing_test -- --ignored --nocapture`
- `clippy -D warnings` clean both modes; `cargo fmt` applied.
- Security review (predicate path) and code review both completed.

### ⚠️ Build dependency
Building with `--features semantic-search` now also requires **`protoc`** (lancedb → lance → prost). The default build is unaffected. The Dockerfile/CI must add `protobuf-compiler` before the feature is enabled in deployment — documented in `docs/SEMANTIC_SEARCH_PLAN.md`.