### PR TITLE
feat(semantic): search-engine toggle, result badges & capabilities endpoint (phase 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ klask-rs/.env
 klask-react/.env
 klask-rs/vector-index/
 klask-rs/models/models--jinaai--jina-embeddings-v2-base-code/
+klask-rs/models/models--Xenova--bge-small-en-v1.5/

--- a/docs/SEMANTIC_SEARCH_PLAN.md
+++ b/docs/SEMANTIC_SEARCH_PLAN.md
@@ -237,6 +237,36 @@ Reproduce with:
   and the UI shows a small badge per result in hybrid/semantic mode.
 - **Admin card** (model/dimension, chunk count, rebuild + progress) already
   shipped in Phase 3; nothing further needed here.
+- **Hydration fixes (post-Phase 4 field findings).** Semantic/hybrid results
+  initially displayed the Tantivy hydration score (BM25 / 1.0) and the whole
+  file as snippet. The query path now sets `score` to the cosine similarity
+  (`1 - distance`, clamped to [0,1]) in semantic mode and the RRF fused score
+  in hybrid mode, anchors `line_number` to the best-matching chunk and trims
+  `content_snippet` to that chunk's line range.
+- **Performance findings & fixes (measured on a dev machine, jina-v2-base-code
+  on CPU):**
+  - fastembed truncates every input at **512 tokens** (its default; now set
+    explicitly as `MAX_SEQUENCE_TOKENS` in `semantic::embedder`). A 60-line
+    code chunk is ~800 tokens, so chunk tails were silently *not embedded*,
+    and per-chunk cost was a flat ~1 s regardless of chunk size. Chunk
+    defaults are now **45 lines / 10 overlap** (stride 35) so every line falls
+    inside the embedded window of at least one chunk.
+  - Embedding cost is ~1 s/chunk with jina-v2-base-code and ~0.27 s/chunk with
+    `Xenova/bge-small-en-v1.5` (3.7×). Model choice — not chunk size — is the
+    indexing-throughput lever; switching models changes the dimension and
+    requires a vector-store wipe + backfill (enforced at open).
+  - The query path and the indexing worker used to share one ONNX session
+    behind a mutex, so an interactive search could wait tens of seconds behind
+    an indexing batch. `init_vector_indexer` now loads a **dedicated session
+    for the worker** (falls back to sharing if the second load fails), keeping
+    query embedding at ~35 ms even while indexing.
+- **Embedding-progress visibility.** The backfill previously reported
+  `running=false` once every document was *enqueued*, while the worker kept
+  embedding invisibly for a long time. `VectorIndexer` now tracks a
+  `pending` counter (queued + in-flight files), the backfill stays `running`
+  until the queue drains, the status payload exposes `queue_depth`, and the
+  admin card shows real embedding progress (`processed - queue_depth`) plus a
+  notice when a *crawl* is feeding the semantic index outside a rebuild.
 
 ## 9. Risks & Mitigations
 

--- a/docs/SEMANTIC_SEARCH_PLAN.md
+++ b/docs/SEMANTIC_SEARCH_PLAN.md
@@ -130,7 +130,7 @@ Once this lands, the MCP `search_code` tool gains a `mode` parameter (default
 | **2** | LanceDB store + embedding worker + crawl integration + delete/update lifecycle | ✅ done (this PR) |
 | **3** | Backfill admin job + progress UI | ✅ done (this PR) |
 | **4** | Query path: `mode` param, RRF fusion wiring, API + tests | ✅ done (this PR) |
-| **5** | Frontend toggle + result badges + admin card | planned |
+| **5** | Frontend toggle + result badges + admin card | ✅ done (this PR) |
 | **6** | MCP `mode` param; eval pass (latency P95, recall@10 vs keyword) and tuning | planned |
 
 **Phase 1 measurements** (debug build, CPU, `Xenova/bge-small-en-v1.5`, 384 dims):
@@ -213,6 +213,30 @@ Reproduce with:
 - **Frontend:** API plumbing only (optional `mode` in `SearchQuery` /
   `useMultiSelectSearch`, sent only when non-default). The mode **toggle UI**,
   result badges and snippet-range rendering are Phase 5.
+
+**Phase 5 notes:**
+- **Engine toggle.** `SearchPageV3` gains a Keyword | Hybrid | Semantic segmented
+  control, persisted in the URL as `mode=` (omitted when keyword, so plain
+  keyword URLs stay clean and backward compatible) and wired into the existing
+  `mode` param of `useMultiSelectSearch`. It is **orthogonal** to the keyword-engine
+  toggles (fuzzy/regex/case) — those choose how the keyword engine matches; this
+  chooses which engine answers.
+- **Availability gating.** The admin `status` endpoint is admin-only, so the
+  regular search page can't use it to decide whether to show the toggle. Added a
+  lightweight authenticated **`GET /api/search/capabilities`** → `{ semantic_enabled }`
+  (true only when the feature is built, the model loaded, and the store opened);
+  the toggle renders only when true and degrades to hidden if the endpoint is
+  unreachable. Capabilities are static for the process lifetime, so the hook
+  caches them indefinitely.
+- **Result badges (match provenance).** Phase 4 hydrated results without saying
+  which engine matched. Phase 5 adds `MatchSource` (`keyword`/`semantic`/`both`)
+  on `SearchResult`, populated in the query path — `hydrate_semantic_only` tags
+  every hit `Semantic`; `hybrid_fuse` tags each fused file by membership in the
+  keyword/vector rankings (`Both` when in both). It serializes with
+  `skip_serializing_if = "Option::is_none"` so the keyword response is unchanged,
+  and the UI shows a small badge per result in hybrid/semantic mode.
+- **Admin card** (model/dimension, chunk count, rebuild + progress) already
+  shipped in Phase 3; nothing further needed here.
 
 ## 9. Risks & Mitigations
 

--- a/klask-react/src/api/searchCapabilities.ts
+++ b/klask-react/src/api/searchCapabilities.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+/**
+ * What the server's search engine can do, for the regular (non-admin) search UI.
+ * Mirrors the backend `SearchCapabilities` (GET /api/search/capabilities).
+ */
+export interface SearchCapabilities {
+  /** Semantic/hybrid modes are usable (feature built + model loaded + store open). */
+  semantic_enabled: boolean;
+}
+
+const searchCapabilityKeys = {
+  all: ['search-capabilities'] as const,
+};
+
+async function fetchSearchCapabilities(): Promise<SearchCapabilities> {
+  const data = await api.get<SearchCapabilities>('/api/search/capabilities');
+  // Defensive: an old/misbehaving backend just means "semantic off".
+  return { semantic_enabled: typeof data?.semantic_enabled === 'boolean' ? data.semantic_enabled : false };
+}
+
+/**
+ * Whether semantic/hybrid search is available on this server.
+ *
+ * Capabilities are effectively static for the life of the server process, so
+ * this is cached aggressively and never refetched in the background. Degrades
+ * gracefully: if the endpoint is unreachable the toggle simply stays hidden.
+ */
+export function useSearchCapabilities() {
+  return useQuery({
+    queryKey: searchCapabilityKeys.all,
+    queryFn: fetchSearchCapabilities,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    retry: 1,
+    throwOnError: false,
+  });
+}

--- a/klask-react/src/api/semanticIndex.ts
+++ b/klask-react/src/api/semanticIndex.ts
@@ -16,6 +16,8 @@ export interface SemanticStatusResponse {
   total: number | null;
   /** Chunks currently stored in the vector index. */
   chunks_indexed: number;
+  /** Files handed to the embedding worker but not yet embedded (queued + in-flight). */
+  queue_depth: number;
   /** Embedding model id the index is built with. */
   model: string | null;
   /** Embedding dimension. */
@@ -56,18 +58,22 @@ async function fetchSemanticStatus(): Promise<SemanticStatusResponse> {
 /**
  * Poll the semantic index status.
  *
- * Polls automatically every `runningIntervalMs` *only while a rebuild is
- * running*, and stops once it finishes — driven off the query's own data via a
- * function `refetchInterval`, so the component calls this hook exactly once
- * (no duplicate queries, no manual timers).
+ * Polls automatically every `runningIntervalMs` while a rebuild is running
+ * *or* the embedding worker still has queued files (e.g. a crawl feeding the
+ * semantic index), and stops once both are idle — driven off the query's own
+ * data via a function `refetchInterval`, so the component calls this hook
+ * exactly once (no duplicate queries, no manual timers).
  */
 export function useSemanticStatus(runningIntervalMs = 1500) {
   return useQuery({
     queryKey: semanticKeys.status(),
     queryFn: fetchSemanticStatus,
     staleTime: 2000,
-    // `query.state.data` is the latest fetched status; poll while running.
-    refetchInterval: (query) => (query.state.data?.running ? runningIntervalMs : false),
+    // `query.state.data` is the latest fetched status; poll while working.
+    refetchInterval: (query) => {
+      const status = query.state.data;
+      return status?.running || (status?.queue_depth ?? 0) > 0 ? runningIntervalMs : false;
+    },
     retry: 1,
     retryDelay: 1000,
     // Degrade gracefully: if the endpoint is unreachable, the card just hides.

--- a/klask-react/src/components/search/SearchResult.tsx
+++ b/klask-react/src/components/search/SearchResult.tsx
@@ -7,7 +7,7 @@ import {
   ArrowTopRightOnSquareIcon
 } from '@heroicons/react/24/outline';
 import { RepositoryBadge } from '../ui/RepositoryBadge';
-import type { SearchResult as SearchResultType } from '../../types';
+import type { SearchResult as SearchResultType, MatchSource } from '../../types';
 
 interface SearchResultProps {
   result: SearchResultType;
@@ -16,6 +16,38 @@ interface SearchResultProps {
   className?: string;
   regexSearch?: boolean;
 }
+
+/** Where a hybrid/semantic result came from, for at-a-glance trust/debugging. */
+const MATCH_SOURCE_BADGE: Record<MatchSource, { label: string; title: string; className: string }> = {
+  keyword: {
+    label: 'Keyword',
+    title: 'Matched by classic full-text (BM25) search.',
+    className: 'bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-200',
+  },
+  semantic: {
+    label: 'Semantic',
+    title: 'Matched by meaning-based vector search.',
+    className: 'bg-purple-50 dark:bg-purple-900 text-purple-700 dark:text-purple-200',
+  },
+  both: {
+    label: 'Both',
+    title: 'Matched by both keyword and semantic search.',
+    className: 'bg-indigo-50 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-200',
+  },
+};
+
+const MatchSourceBadge: React.FC<{ source: MatchSource }> = ({ source }) => {
+  const badge = MATCH_SOURCE_BADGE[source];
+  if (!badge) return null;
+  return (
+    <span
+      title={badge.title}
+      className={`inline-flex items-center px-2 py-1 text-xs font-medium rounded ${badge.className}`}
+    >
+      {badge.label}
+    </span>
+  );
+};
 
 export const SearchResult: React.FC<SearchResultProps> = ({
   result,
@@ -105,6 +137,7 @@ export const SearchResult: React.FC<SearchResultProps> = ({
           
           {/* Right side: Badges and View File button */}
           <div className="flex items-center space-x-2 flex-shrink-0">
+            {result.match_source && <MatchSourceBadge source={result.match_source} />}
             <span className="inline-flex items-center px-2 py-1 text-xs font-medium bg-blue-50 dark:bg-blue-900 text-blue-700 dark:text-blue-200 rounded">
               {result.extension || 'N/A'}
             </span>

--- a/klask-react/src/components/search/__tests__/SearchResult.match-source.test.tsx
+++ b/klask-react/src/components/search/__tests__/SearchResult.match-source.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SearchResult } from '../SearchResult';
+import type { SearchResult as SearchResultType, MatchSource } from '../../../types';
+
+const baseResult: SearchResultType = {
+  file_id: '1',
+  doc_address: '0:1',
+  name: 'auth.rs',
+  path: 'src/auth.rs',
+  content_snippet: 'fn login() {}',
+  project: 'klask',
+  version: 'main',
+  extension: 'rs',
+  score: 0.9,
+};
+
+function renderWith(match_source?: MatchSource) {
+  return render(
+    <SearchResult result={{ ...baseResult, match_source }} query="login" onFileClick={vi.fn()} />
+  );
+}
+
+describe('SearchResult - match source badge', () => {
+  it('renders no badge when match_source is absent (keyword path)', () => {
+    renderWith(undefined);
+    expect(screen.queryByText('Keyword')).not.toBeInTheDocument();
+    expect(screen.queryByText('Semantic')).not.toBeInTheDocument();
+    expect(screen.queryByText('Both')).not.toBeInTheDocument();
+  });
+
+  it('renders the Semantic badge', () => {
+    renderWith('semantic');
+    expect(screen.getByText('Semantic')).toBeInTheDocument();
+  });
+
+  it('renders the Both badge', () => {
+    renderWith('both');
+    expect(screen.getByText('Both')).toBeInTheDocument();
+  });
+
+  it('renders the Keyword badge', () => {
+    renderWith('keyword');
+    expect(screen.getByText('Keyword')).toBeInTheDocument();
+  });
+});

--- a/klask-react/src/features/admin/__tests__/SemanticIndexCard.test.tsx
+++ b/klask-react/src/features/admin/__tests__/SemanticIndexCard.test.tsx
@@ -25,6 +25,7 @@ function setStatus(data: Partial<semanticApi.SemanticStatusResponse> | undefined
         processed: 0,
         total: null,
         chunks_indexed: 0,
+        queue_depth: 0,
         model: 'mock-model',
         dimension: 384,
         error: null,
@@ -86,6 +87,25 @@ describe('SemanticIndexCard', () => {
     expect(bar).toHaveAttribute('aria-valuenow', '25');
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
     expect(screen.getByText(/50 \/ 200 documents/)).toBeInTheDocument();
+  });
+
+  it('reports embedding progress, not enqueue progress, while running', () => {
+    // 200 documents enqueued but 150 still waiting in the worker queue:
+    // only 50 are really embedded → 25%, with the queue depth surfaced.
+    setStatus({ running: true, processed: 200, total: 200, queue_depth: 150 });
+    render(<SemanticIndexCard />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '25');
+    expect(screen.getByText(/50 \/ 200 documents/)).toBeInTheDocument();
+    expect(screen.getByText(/150.*queued/)).toBeInTheDocument();
+  });
+
+  it('shows a crawl-embedding notice when the queue is busy outside a rebuild', () => {
+    setStatus({ running: false, queue_depth: 42, chunks_indexed: 10 });
+    render(<SemanticIndexCard />);
+    expect(screen.getByText(/42 files awaiting embedding/)).toBeInTheDocument();
+    // Not a rebuild: no progress bar, and the rebuild button stays available.
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /rebuild index/i })).toBeInTheDocument();
   });
 
   it('surfaces the last error after a failed run', () => {

--- a/klask-react/src/features/admin/components/SemanticIndexCard.tsx
+++ b/klask-react/src/features/admin/components/SemanticIndexCard.tsx
@@ -62,7 +62,13 @@ export const SemanticIndexCard: React.FC = () => {
   }
 
   const total = status.total ?? 0;
-  const progressPct = total > 0 ? Math.min(100, Math.round((status.processed / total) * 100)) : 0;
+  const queueDepth = status.queue_depth ?? 0;
+  // Real embedding progress: `processed` counts documents *enqueued*, so
+  // subtract what is still waiting in the worker queue.
+  const embedded = Math.max(0, status.processed - queueDepth);
+  const progressPct = total > 0 ? Math.min(100, Math.round((embedded / total) * 100)) : 0;
+  // A crawl (not a rebuild) is feeding the semantic index right now.
+  const crawlEmbedding = !running && queueDepth > 0;
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
@@ -96,13 +102,16 @@ export const SemanticIndexCard: React.FC = () => {
           </div>
         </div>
 
-        {/* Progress while running */}
+        {/* Progress while a rebuild is running */}
         {running && (
           <div className="space-y-2">
             <div className="flex items-center justify-between text-sm">
               <span className="text-gray-700 dark:text-gray-300">
-                Rebuilding… {status.processed.toLocaleString()}
+                Embedding… {embedded.toLocaleString()}
                 {total > 0 ? ` / ${total.toLocaleString()}` : ''} documents
+                {queueDepth > 0 ? (
+                  <span className="text-gray-500 dark:text-gray-400"> ({queueDepth.toLocaleString()} queued)</span>
+                ) : null}
               </span>
               <span className="text-gray-500 dark:text-gray-400">{progressPct}%</span>
             </div>
@@ -116,6 +125,17 @@ export const SemanticIndexCard: React.FC = () => {
                 aria-valuemax={100}
               />
             </div>
+          </div>
+        )}
+
+        {/* A crawl is feeding the semantic index (no known total, so no bar) */}
+        {crawlEmbedding && (
+          <div className="flex items-center gap-2 text-sm text-purple-700 dark:text-purple-300 bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-md p-3">
+            <LoadingSpinner size="sm" />
+            <span>
+              Semantic indexing in progress — {queueDepth.toLocaleString()} file
+              {queueDepth === 1 ? '' : 's'} awaiting embedding (from a crawl).
+            </span>
           </div>
         )}
 

--- a/klask-react/src/features/search/SearchPageV3.tsx
+++ b/klask-react/src/features/search/SearchPageV3.tsx
@@ -3,8 +3,9 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { SearchBar } from '../../components/search/SearchBar';
 import { SearchResults } from '../../components/search/SearchResults';
 import { useMultiSelectSearch, useSearchHistory } from '../../hooks/useSearch';
+import { useSearchCapabilities } from '../../api/searchCapabilities';
 import { getErrorMessage } from '../../lib/api';
-import type { SearchResult } from '../../types';
+import type { SearchResult, SearchMode } from '../../types';
 import { useSearchFiltersContext } from '../../contexts/SearchFiltersContext';
 import {
   ClockIcon,
@@ -29,6 +30,13 @@ const SearchPageV3: React.FC = () => {
   });
 
   const [caseSensitive, setCaseSensitive] = useState(false);
+
+  // Semantic search engine selection (keyword | hybrid | semantic). Orthogonal
+  // to the keyword-engine variants (fuzzy/regex) above. Only meaningful when the
+  // server reports semantic search is available.
+  const [semanticMode, setSemanticMode] = useState<SearchMode>('keyword');
+  const { data: capabilities } = useSearchCapabilities();
+  const semanticAvailable = capabilities?.semantic_enabled ?? false;
 
   // Derive boolean flags from searchMode for backward compatibility
   const fuzzySearch = searchMode === 'fuzzy';
@@ -99,13 +107,19 @@ const SearchPageV3: React.FC = () => {
       params.set('case_sensitive', 'true');
     }
 
+    // Persist the semantic mode only when it differs from the default so plain
+    // keyword URLs stay clean and backward compatible.
+    if (semanticMode !== 'keyword') {
+      params.set('mode', semanticMode);
+    }
+
     if (page > 1) {
       params.set('page', page.toString());
     }
 
     const newURL = params.toString() ? `${window.location.pathname}?${params.toString()}` : window.location.pathname;
     window.history.replaceState(null, '', newURL);
-  }, [fuzzySearch, regexSearch, caseSensitive]);
+  }, [fuzzySearch, regexSearch, caseSensitive, semanticMode]);
 
   // Track if we're initializing to avoid double URL updates
   const [isInitializing, setIsInitializing] = useState(true);
@@ -131,6 +145,7 @@ const SearchPageV3: React.FC = () => {
     const urlFuzzySearch = urlParams.get('fuzzySearch') === 'true';
     const urlRegexSearch = urlParams.get('regexSearch') === 'true';
     const urlCaseSensitive = urlParams.get('case_sensitive') === 'true';
+    const urlMode = urlParams.get('mode');
 
     const urlPage = parseInt(urlParams.get('page') || '1', 10);
 
@@ -168,6 +183,12 @@ const SearchPageV3: React.FC = () => {
     }
 
     setCaseSensitive(urlCaseSensitive);
+    // Restore the semantic mode from the URL (ignore unknown values).
+    if (urlMode === 'semantic' || urlMode === 'hybrid') {
+      setSemanticMode(urlMode);
+    } else {
+      setSemanticMode('keyword');
+    }
     setCurrentPage(urlPage);
     setIsInitializing(false);
   }, [location.search, setFilters]);
@@ -176,7 +197,7 @@ const SearchPageV3: React.FC = () => {
   useEffect(() => {
     if (isInitializing) return;
     updateURL(query, filters, currentPage);
-  }, [query, filters, currentPage, updateURL, isInitializing, fuzzySearch, regexSearch, caseSensitive]);
+  }, [query, filters, currentPage, updateURL, isInitializing, fuzzySearch, regexSearch, caseSensitive, semanticMode]);
 
   // Reset to page 1 when filters change (prevents showing empty results on non-existent pages)
   useEffect(() => {
@@ -224,7 +245,7 @@ const SearchPageV3: React.FC = () => {
     sizeRange: filters?.size,
   }, currentPage, {
     enabled: !!query.trim(),
-  }, fuzzySearch, regexSearch, regexFlagsString, caseSensitive);
+  }, fuzzySearch, regexSearch, regexFlagsString, caseSensitive, semanticMode);
 
   const results = searchData?.results || [];
   const totalResults = searchData?.total || 0;
@@ -312,6 +333,11 @@ const SearchPageV3: React.FC = () => {
   const handleCaseSensitiveToggle = useCallback(() => {
     setCaseSensitive(prev => !prev);
     setCurrentPage(1); // Reset to page 1 when toggling case sensitivity
+  }, []);
+
+  const handleSemanticModeChange = useCallback((mode: SearchMode) => {
+    setSemanticMode(mode);
+    setCurrentPage(1); // Reset to page 1 when changing the search engine
   }, []);
 
   // Regex flags toggle handlers
@@ -458,6 +484,44 @@ const SearchPageV3: React.FC = () => {
             </div>
           )}
         </div>
+
+        {/* Semantic search engine selector (only when the server supports it).
+            Orthogonal to the keyword-engine toggles above: it picks which
+            engine answers the query. */}
+        {semanticAvailable && (
+          <div className="mt-4 flex items-center gap-3">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400 flex items-center gap-1">
+              <SparklesIcon className="h-4 w-4 text-blue-500" />
+              Engine
+            </span>
+            <div
+              role="group"
+              aria-label="Search engine mode"
+              className="inline-flex rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden"
+            >
+              {([
+                { mode: 'keyword' as const, label: 'Keyword', title: 'Classic full-text (BM25) search — exact terms and patterns.' },
+                { mode: 'hybrid' as const, label: 'Hybrid', title: 'Combines keyword and meaning-based results (recommended for natural-language queries).' },
+                { mode: 'semantic' as const, label: 'Semantic', title: 'Meaning-based vector search only — find code by intent, not exact words.' },
+              ]).map(({ mode, label, title }) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => handleSemanticModeChange(mode)}
+                  aria-pressed={semanticMode === mode}
+                  title={title}
+                  className={`px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset ${
+                    semanticMode === mode
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Search History */}
         {!query && history.length > 0 && (

--- a/klask-react/src/features/search/__tests__/SearchPageV3.semantic-mode.test.tsx
+++ b/klask-react/src/features/search/__tests__/SearchPageV3.semantic-mode.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import SearchPageV3 from '../SearchPageV3';
+import * as useSearch from '../../../hooks/useSearch';
+import * as searchCapabilities from '../../../api/searchCapabilities';
+import type { SearchResponse } from '../../../types';
+import { SearchFiltersProvider } from '../../../contexts/SearchFiltersContext';
+
+vi.mock('../../../hooks/useSearch');
+vi.mock('../../../api/searchCapabilities');
+
+const createWrapper = (initialEntries: string[] = ['/search']) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <SearchFiltersProvider>
+        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      </SearchFiltersProvider>
+    </QueryClientProvider>
+  );
+};
+
+const mockSearchResponse: SearchResponse = {
+  results: [],
+  total: 0,
+  page: 1,
+  size: 20,
+  facets: { projects: [], versions: [], extensions: [] },
+} as unknown as SearchResponse;
+
+function mockSearchHooks() {
+  vi.mocked(useSearch.useSearchFilters).mockReturnValue({
+    data: { projects: [], versions: [], extensions: [], repositories: [], languages: [] },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useSearch.useSearchFilters>);
+
+  vi.mocked(useSearch.useFacetsWithFilters).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useSearch.useFacetsWithFilters>);
+
+  vi.mocked(useSearch.useSearchHistory).mockReturnValue({
+    history: [],
+    addToHistory: vi.fn(),
+    clearHistory: vi.fn(),
+  });
+
+  vi.mocked(useSearch.useMultiSelectSearch).mockReturnValue({
+    data: mockSearchResponse,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useSearch.useMultiSelectSearch>);
+}
+
+function mockCapabilities(enabled: boolean) {
+  vi.mocked(searchCapabilities.useSearchCapabilities).mockReturnValue({
+    data: { semantic_enabled: enabled },
+    isLoading: false,
+    error: null,
+  } as unknown as ReturnType<typeof searchCapabilities.useSearchCapabilities>);
+}
+
+describe('SearchPageV3 - Semantic Mode Toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchHooks();
+  });
+
+  it('hides the engine selector when the server does not support semantic search', () => {
+    mockCapabilities(false);
+    render(<SearchPageV3 />, { wrapper: createWrapper() });
+    expect(screen.queryByRole('group', { name: /search engine mode/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the engine selector when semantic search is available', async () => {
+    mockCapabilities(true);
+    render(<SearchPageV3 />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByRole('group', { name: /search engine mode/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Keyword' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Hybrid' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Semantic' })).toBeInTheDocument();
+  });
+
+  it('passes the selected mode to the search hook when changed', async () => {
+    mockCapabilities(true);
+    const user = userEvent.setup();
+    render(<SearchPageV3 />, { wrapper: createWrapper() });
+
+    await user.click(screen.getByRole('button', { name: 'Hybrid' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Hybrid' })).toHaveAttribute('aria-pressed', 'true');
+    });
+    // useMultiSelectSearch is called with mode as the last positional arg.
+    const calls = vi.mocked(useSearch.useMultiSelectSearch).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[lastCall.length - 1]).toBe('hybrid');
+  });
+
+  it('initializes the mode from the URL', async () => {
+    mockCapabilities(true);
+    render(<SearchPageV3 />, { wrapper: createWrapper(['/search?q=foo&mode=semantic']) });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Semantic' })).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+});

--- a/klask-react/src/types/index.ts
+++ b/klask-react/src/types/index.ts
@@ -154,6 +154,10 @@ export interface File {
 // built with semantic search enabled — otherwise the API degrades to keyword.
 export type SearchMode = 'keyword' | 'semantic' | 'hybrid';
 
+// Which engine(s) a result matched in, for the hybrid/semantic result badge.
+// Absent on keyword results. Mirrors the backend `MatchSource`.
+export type MatchSource = 'keyword' | 'semantic' | 'both';
+
 export interface SearchQuery {
   query: string;
   project?: string;
@@ -178,6 +182,7 @@ export interface SearchResult {
   score: number;
   line_number?: number;
   repository_name?: string; // Repository name from backend
+  match_source?: MatchSource; // Which engine(s) matched (hybrid/semantic only)
 }
 
 export interface FacetValue {

--- a/klask-rs/.env.example
+++ b/klask-rs/.env.example
@@ -30,8 +30,9 @@ SEMANTIC_SEARCH_MODEL=jinaai/jina-embeddings-v2-base-code
 SEMANTIC_SEARCH_CACHE_DIR=./models
 # Directory for the embedded vector store (LanceDB), sibling of the Tantivy index.
 SEMANTIC_SEARCH_VECTOR_DIR=./vector-index
-SEMANTIC_SEARCH_CHUNK_MAX_LINES=60
-SEMANTIC_SEARCH_CHUNK_OVERLAP_LINES=15
+# Sized to fit the embedder 512-token truncation window (lines beyond it are not embedded)
+SEMANTIC_SEARCH_CHUNK_MAX_LINES=45
+SEMANTIC_SEARCH_CHUNK_OVERLAP_LINES=10
 SEMANTIC_SEARCH_BATCH_SIZE=32
 # Bounded embedding queue: the crawl blocks when full (no chunks dropped).
 SEMANTIC_SEARCH_QUEUE_CAPACITY=1000

--- a/klask-rs/src/api/admin/semantic.rs
+++ b/klask-rs/src/api/admin/semantic.rs
@@ -39,6 +39,9 @@ pub struct SemanticStatusResponse {
     pub total: Option<u64>,
     /// Chunks currently stored in the vector index.
     pub chunks_indexed: u64,
+    /// Files handed to the embedding worker but not yet embedded. Non-zero
+    /// while a rebuild or a crawl is still feeding the semantic index.
+    pub queue_depth: u64,
     /// Embedding model id the index is built with.
     pub model: Option<String>,
     /// Embedding dimension.
@@ -62,6 +65,7 @@ impl SemanticStatusResponse {
             processed: 0,
             total: None,
             chunks_indexed: 0,
+            queue_depth: 0,
             model: None,
             dimension: None,
             error: None,
@@ -100,6 +104,7 @@ async fn get_semantic_status(
             processed: s.processed,
             total: s.total,
             chunks_indexed: s.chunks_indexed,
+            queue_depth: s.queue_depth,
             model: Some(s.model),
             dimension: Some(s.dimension),
             error: s.error,

--- a/klask-rs/src/api/search.rs
+++ b/klask-rs/src/api/search.rs
@@ -1,5 +1,5 @@
 use crate::auth::extractors::{AppState, AuthenticatedUser};
-use crate::services::{SearchMode, SearchQuery};
+use crate::services::{MatchSource, SearchMode, SearchQuery};
 use anyhow::Result;
 use axum::{
     Router,
@@ -124,12 +124,43 @@ pub struct SearchResult {
     pub extension: String,
     pub score: f32,
     pub line_number: Option<u32>,
+    /// Which engine(s) this result matched in (hybrid/semantic only); omitted for
+    /// keyword results so the keyword response is unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_source: Option<MatchSource>,
+}
+
+/// Whether the semantic/hybrid search modes are usable on this server, surfaced
+/// to the regular search UI (non-admin) so it only shows the mode toggle when it
+/// would actually do something. True only when the feature is built in, the
+/// embedding model loaded, and the vector store opened.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SearchCapabilities {
+    pub semantic_enabled: bool,
 }
 
 pub async fn create_router() -> Result<Router<AppState>> {
-    let router = Router::new().route("/", get(search_files)).route("/facets", get(get_facets_with_filters));
+    let router = Router::new()
+        .route("/", get(search_files))
+        .route("/facets", get(get_facets_with_filters))
+        .route("/capabilities", get(get_capabilities));
 
     Ok(router)
+}
+
+/// Report whether semantic/hybrid search is available (see [`SearchCapabilities`]).
+/// Authenticated but not admin-gated — every user needs it to render the toggle.
+async fn get_capabilities(
+    _auth: AuthenticatedUser,
+    State(app_state): State<AppState>,
+) -> Json<SearchCapabilities> {
+    let _ = &app_state; // used only in the feature build below
+    #[cfg(feature = "semantic-search")]
+    let semantic_enabled = app_state.semantic_embedder.is_some() && app_state.semantic_indexer.is_some();
+    #[cfg(not(feature = "semantic-search"))]
+    let semantic_enabled = false;
+
+    Json(SearchCapabilities { semantic_enabled })
 }
 
 /// Execute a search, dispatching to the semantic/hybrid query path when the
@@ -229,6 +260,7 @@ async fn search_files(
                     extension: r.extension,
                     score: r.score,
                     line_number: r.line_number,
+                    match_source: r.match_source,
                 })
                 .collect();
 

--- a/klask-rs/src/api/search.rs
+++ b/klask-rs/src/api/search.rs
@@ -150,10 +150,7 @@ pub async fn create_router() -> Result<Router<AppState>> {
 
 /// Report whether semantic/hybrid search is available (see [`SearchCapabilities`]).
 /// Authenticated but not admin-gated — every user needs it to render the toggle.
-async fn get_capabilities(
-    _auth: AuthenticatedUser,
-    State(app_state): State<AppState>,
-) -> Json<SearchCapabilities> {
+async fn get_capabilities(_auth: AuthenticatedUser, State(app_state): State<AppState>) -> Json<SearchCapabilities> {
     let _ = &app_state; // used only in the feature build below
     #[cfg(feature = "semantic-search")]
     let semantic_enabled = app_state.semantic_embedder.is_some() && app_state.semantic_indexer.is_some();

--- a/klask-rs/src/config.rs
+++ b/klask-rs/src/config.rs
@@ -150,14 +150,18 @@ impl AppConfig {
                 cache_dir: std::env::var("SEMANTIC_SEARCH_CACHE_DIR").unwrap_or_else(|_| "./models".to_string()),
                 vector_store_dir: std::env::var("SEMANTIC_SEARCH_VECTOR_DIR")
                     .unwrap_or_else(|_| "./vector-index".to_string()),
+                // Sized so a typical code chunk stays within the embedder's
+                // 512-token truncation window (see MAX_SEQUENCE_TOKENS in
+                // semantic::embedder) — lines past that budget are silently
+                // invisible to semantic search.
                 chunk_max_lines: std::env::var("SEMANTIC_SEARCH_CHUNK_MAX_LINES")
-                    .unwrap_or_else(|_| "60".to_string())
+                    .unwrap_or_else(|_| "45".to_string())
                     .parse()
-                    .unwrap_or(60),
+                    .unwrap_or(45),
                 chunk_overlap_lines: std::env::var("SEMANTIC_SEARCH_CHUNK_OVERLAP_LINES")
-                    .unwrap_or_else(|_| "15".to_string())
+                    .unwrap_or_else(|_| "10".to_string())
                     .parse()
-                    .unwrap_or(15),
+                    .unwrap_or(10),
                 batch_size: std::env::var("SEMANTIC_SEARCH_BATCH_SIZE")
                     .unwrap_or_else(|_| "32".to_string())
                     .parse()

--- a/klask-rs/src/services/search.rs
+++ b/klask-rs/src/services/search.rs
@@ -95,6 +95,11 @@ pub struct SearchResult {
     pub extension: String,
     pub score: f32,
     pub line_number: Option<u32>,
+    /// Which engine(s) this result matched in (hybrid/semantic only). `None` for
+    /// keyword results — the keyword path never sets it, keeping its output
+    /// unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_source: Option<MatchSource>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -144,6 +149,20 @@ pub enum SearchMode {
     Keyword,
     Semantic,
     Hybrid,
+}
+
+/// Which engine(s) a *result* matched in, for the hybrid/semantic UI badge
+/// (plan §6). Only meaningful for semantic-aware modes; keyword results leave
+/// `SearchResult::match_source` as `None` so the keyword path and response are
+/// byte-for-byte unchanged. `Both` is set in hybrid mode when a file surfaced
+/// in both the keyword and the vector ranking.
+#[cfg_attr(not(feature = "semantic-search"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MatchSource {
+    Keyword,
+    Semantic,
+    Both,
 }
 
 impl SearchMode {
@@ -1217,6 +1236,7 @@ impl SearchService {
                     extension,
                     score,
                     line_number,
+                    match_source: None,
                 });
             }
         }
@@ -1383,6 +1403,7 @@ impl SearchService {
                     extension,
                     score: 1.0,
                     line_number: None,
+                    match_source: None,
                 }))
             }
             Err(_) => {
@@ -1471,6 +1492,7 @@ impl SearchService {
                 extension,
                 score: *score,
                 line_number: None,
+                match_source: None,
             }));
         }
 

--- a/klask-rs/src/services/semantic/backfill.rs
+++ b/klask-rs/src/services/semantic/backfill.rs
@@ -42,6 +42,10 @@ pub struct BackfillStatus {
     pub total: Option<u64>,
     /// Chunks currently stored in the vector index (updated as the job runs).
     pub chunks_indexed: u64,
+    /// Files enqueued to the embedding worker but not yet embedded (queued +
+    /// in-flight). Non-zero outside a backfill means a crawl is feeding the
+    /// semantic index right now.
+    pub queue_depth: u64,
     /// Embedding model id (so the UI can show what the index was built with).
     pub model: String,
     /// Embedding dimension.
@@ -110,6 +114,7 @@ impl BackfillController {
             processed: state.processed,
             total: state.total,
             chunks_indexed,
+            queue_depth: self.indexer.pending(),
             model: self.model.clone(),
             dimension: self.dimension,
             error: state.error.clone(),
@@ -166,8 +171,8 @@ impl BackfillController {
     }
 
     /// The actual rebuild: clear the store, then stream every Tantivy document
-    /// into the embedding worker. Returns once all documents are *enqueued*
-    /// (the worker keeps embedding in the background afterwards).
+    /// into the embedding worker, then wait for the worker to drain its queue
+    /// — so `running` covers the whole rebuild, embedding included.
     async fn run(&self) -> Result<()> {
         // Wipe the vector index so a re-run never leaves stale or duplicated
         // rows (the worker upserts per file_id, but a rebuild should also drop
@@ -237,6 +242,15 @@ impl BackfillController {
             }
             Ok(Err(e)) => return Err(e),
             Err(join_err) => return Err(anyhow!("backfill reader task panicked: {join_err}")),
+        }
+
+        // Everything is enqueued, but the worker is still embedding. Stay
+        // "running" until the queue drains so the admin UI reports the real
+        // end of the rebuild, not just the end of the enqueue phase. A cancel
+        // stops the wait, but jobs already queued will still be embedded
+        // (they cannot be un-queued).
+        while self.indexer.pending() > 0 && !self.cancel.load(Ordering::SeqCst) {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
 
         if self.cancel.load(Ordering::SeqCst) {
@@ -382,6 +396,59 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         assert_eq!(indexer.count().await.unwrap(), chunks);
         assert_eq!(controller.status().await.processed, 1);
+    }
+
+    /// Embeds slowly so the drain phase is observable: `running` must stay
+    /// true until the worker queue is empty (not just until enqueue ends),
+    /// and whenever `running` is false the reported queue depth must be zero.
+    #[tokio::test]
+    async fn test_running_covers_embedding_until_queue_drained() {
+        struct SlowProvider;
+        impl EmbeddingProvider for SlowProvider {
+            fn dimension(&self) -> usize {
+                DIM
+            }
+            fn model_id(&self) -> &str {
+                "slow-mock"
+            }
+            fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                Ok(texts.iter().map(|_| vec![1.0; DIM]).collect())
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let search = Arc::new(SearchService::new(tmp.path().join("tantivy")).unwrap());
+        let store: Arc<dyn VectorStore> =
+            Arc::new(LanceVectorStore::open(tmp.path().join("vectors"), DIM).await.unwrap());
+        let indexer = Arc::new(VectorIndexer::start(
+            Arc::new(SlowProvider),
+            store,
+            ChunkOptions::default(),
+            32,
+            64,
+        ));
+        for i in 0..5 {
+            index_doc(&search, "repo", &format!("f{i}.rs"), "fn f() {}").await;
+        }
+
+        let controller = BackfillController::new(search, indexer.clone(), "mock".into(), DIM);
+        controller.start().await.unwrap();
+
+        // 5 docs × 100ms embed ≈ 500ms of work + 500ms drain-poll granularity.
+        for _ in 0..600 {
+            let status = controller.status().await;
+            if !status.running {
+                assert_eq!(
+                    status.queue_depth, 0,
+                    "backfill reported finished while files were still awaiting embedding"
+                );
+                assert_eq!(status.processed, 5);
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("backfill did not finish in time");
     }
 
     #[tokio::test]

--- a/klask-rs/src/services/semantic/chunker.rs
+++ b/klask-rs/src/services/semantic/chunker.rs
@@ -34,7 +34,9 @@ pub struct ChunkOptions {
 
 impl Default for ChunkOptions {
     fn default() -> Self {
-        Self { max_lines: 60, overlap_lines: 15 }
+        // Keep in sync with the config defaults (SEMANTIC_SEARCH_CHUNK_*):
+        // sized so a typical code chunk fits the embedder's 512-token window.
+        Self { max_lines: 45, overlap_lines: 10 }
     }
 }
 
@@ -205,9 +207,11 @@ mod tests {
     }
 
     #[test]
-    fn test_default_options_match_plan() {
+    fn test_default_options_fit_embedding_token_budget() {
+        // Sized so a typical code chunk stays within the embedder's 512-token
+        // truncation window (MAX_SEQUENCE_TOKENS in semantic::embedder).
         let options = ChunkOptions::default();
-        assert_eq!(options.max_lines, 60);
-        assert_eq!(options.overlap_lines, 15);
+        assert_eq!(options.max_lines, 45);
+        assert_eq!(options.overlap_lines, 10);
     }
 }

--- a/klask-rs/src/services/semantic/embedder.rs
+++ b/klask-rs/src/services/semantic/embedder.rs
@@ -38,6 +38,15 @@ mod fastembed_provider {
     use std::path::PathBuf;
     use std::sync::Mutex;
 
+    /// Token budget per embedded sequence. fastembed truncates every input at
+    /// this length (its own default is also 512), so text past this point in a
+    /// chunk is invisible to semantic search. The chunker defaults
+    /// (`SEMANTIC_SEARCH_CHUNK_MAX_LINES` / overlap) are sized so a typical
+    /// code chunk fits within this budget — keep them in sync. Raising this
+    /// increases per-chunk inference cost superlinearly (attention is
+    /// quadratic in sequence length).
+    const MAX_SEQUENCE_TOKENS: usize = 512;
+
     /// Embedding provider backed by fastembed (ONNX Runtime, local inference).
     ///
     /// The first initialization downloads the model into `cache_dir`; later
@@ -75,6 +84,7 @@ mod fastembed_provider {
 
             let options = TextInitOptions::new(info.model)
                 .with_cache_dir(PathBuf::from(&config.cache_dir))
+                .with_max_length(MAX_SEQUENCE_TOKENS)
                 .with_show_download_progress(false);
 
             let model = TextEmbedding::try_new(options)

--- a/klask-rs/src/services/semantic/indexer.rs
+++ b/klask-rs/src/services/semantic/indexer.rs
@@ -19,6 +19,7 @@ use super::embedder::EmbeddingProvider;
 use super::store::{ChunkRecord, VectorHit, VectorSearchFilters, VectorStore};
 use anyhow::{Result, anyhow};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 use uuid::Uuid;
@@ -44,6 +45,10 @@ pub struct IndexJob {
 pub struct VectorIndexer {
     tx: mpsc::Sender<IndexJob>,
     store: Arc<dyn VectorStore>,
+    // Files enqueued but not yet fully embedded (queued + in-flight). Lets the
+    // admin UI show that semantic indexing is still working after the crawl /
+    // backfill has finished handing files over.
+    pending: Arc<AtomicU64>,
 }
 
 impl VectorIndexer {
@@ -59,10 +64,17 @@ impl VectorIndexer {
         capacity: usize,
     ) -> Self {
         let (tx, rx) = mpsc::channel(capacity.max(1));
-        let worker = Worker { provider, store: store.clone(), chunk_options, batch_size: batch_size.max(1) };
+        let pending = Arc::new(AtomicU64::new(0));
+        let worker = Worker {
+            provider,
+            store: store.clone(),
+            chunk_options,
+            batch_size: batch_size.max(1),
+            pending: pending.clone(),
+        };
         tokio::spawn(worker.run(rx));
         info!("Semantic embedding worker started (queue capacity {})", capacity.max(1));
-        Self { tx, store }
+        Self { tx, store, pending }
     }
 
     /// Enqueue a file for embedding.
@@ -71,7 +83,19 @@ impl VectorIndexer {
     /// worker has stopped (channel closed) — the caller logs and continues, as
     /// the Tantivy index remains the source of truth.
     pub async fn index_file(&self, job: IndexJob) -> Result<()> {
-        self.tx.send(job).await.map_err(|_| anyhow!("Semantic embedding worker is no longer running"))
+        // Count before sending so `pending` never under-reports; roll back if
+        // the worker is gone and the job was never queued.
+        self.pending.fetch_add(1, Ordering::SeqCst);
+        self.tx.send(job).await.map_err(|_| {
+            self.pending.fetch_sub(1, Ordering::SeqCst);
+            anyhow!("Semantic embedding worker is no longer running")
+        })
+    }
+
+    /// Files enqueued but not yet embedded (queued + in-flight). Zero means
+    /// the semantic index has caught up with everything handed to it.
+    pub fn pending(&self) -> u64 {
+        self.pending.load(Ordering::SeqCst)
     }
 
     /// Delete all chunks of a repository.
@@ -114,6 +138,7 @@ struct Worker {
     store: Arc<dyn VectorStore>,
     chunk_options: ChunkOptions,
     batch_size: usize,
+    pending: Arc<AtomicU64>,
 }
 
 impl Worker {
@@ -124,6 +149,9 @@ impl Worker {
                 // One bad file must never kill the worker: log and keep draining.
                 error!("Semantic indexing failed for file_id={file_id}: {e}");
             }
+            // Failed jobs also count down: pending tracks outstanding work,
+            // not successes.
+            self.pending.fetch_sub(1, Ordering::SeqCst);
         }
         info!("Semantic embedding worker stopped (queue drained)");
     }
@@ -315,6 +343,74 @@ mod tests {
         assert_eq!(store.count().await.unwrap(), 0);
         // Worker still alive: enqueue succeeds.
         assert!(indexer.index_file(job("fn c() {}")).await.is_ok());
+    }
+
+    /// Provider slow enough that jobs observably sit in the queue.
+    struct SlowProvider;
+
+    impl EmbeddingProvider for SlowProvider {
+        fn dimension(&self) -> usize {
+            DIM
+        }
+        fn model_id(&self) -> &str {
+            "slow-mock"
+        }
+        fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            Ok(texts.iter().map(|_| vec![1.0; DIM]).collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pending_tracks_outstanding_work_and_drains_to_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let indexer = VectorIndexer::start(Arc::new(SlowProvider), store.clone(), ChunkOptions::default(), 32, 16);
+
+        assert_eq!(indexer.pending(), 0);
+        for _ in 0..3 {
+            indexer.index_file(job("fn a() {}")).await.unwrap();
+        }
+        // Each embed blocks 100ms, so all three jobs cannot have finished yet.
+        assert!(
+            indexer.pending() >= 1,
+            "jobs should still be outstanding right after enqueue"
+        );
+
+        for _ in 0..100 {
+            if indexer.pending() == 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            indexer.pending(),
+            0,
+            "pending must drain to zero once the worker catches up"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pending_drains_even_when_jobs_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let indexer = VectorIndexer::start(
+            Arc::new(MockProvider { calls: Arc::new(AtomicUsize::new(0)), fail: true }),
+            store.clone(),
+            ChunkOptions::default(),
+            32,
+            16,
+        );
+        indexer.index_file(job("fn a() {}")).await.unwrap();
+        indexer.index_file(job("fn b() {}")).await.unwrap();
+        for _ in 0..100 {
+            if indexer.pending() == 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        // pending tracks outstanding work, not successes: failures count down too.
+        assert_eq!(indexer.pending(), 0);
     }
 
     #[tokio::test]

--- a/klask-rs/src/services/semantic/mod.rs
+++ b/klask-rs/src/services/semantic/mod.rs
@@ -154,7 +154,34 @@ pub async fn init_vector_indexer(
 
     let chunk_options = ChunkOptions { max_lines: config.chunk_max_lines, overlap_lines: config.chunk_overlap_lines };
 
-    let indexer = VectorIndexer::start(provider, store, chunk_options, config.batch_size, config.queue_capacity);
+    // Give the indexing worker its own ONNX session instead of sharing the
+    // query-path provider: a batch embed can hold a session for tens of
+    // seconds, and sharing one session (a Mutex) made interactive searches
+    // wait behind indexing batches. Costs one extra copy of the model in RAM;
+    // if the second load fails, fall back to sharing (slow queries during
+    // indexing, but functional).
+    let worker_provider: Arc<dyn EmbeddingProvider> = match FastEmbedProvider::try_new(config) {
+        Ok(p) => {
+            tracing::info!(
+                "Loaded a dedicated embedding session for indexing (queries no longer wait on indexing batches)"
+            );
+            Arc::new(p)
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Could not load a dedicated indexing session, sharing the query session (searches may stall during indexing): {e}"
+            );
+            provider
+        }
+    };
+
+    let indexer = VectorIndexer::start(
+        worker_provider,
+        store,
+        chunk_options,
+        config.batch_size,
+        config.queue_capacity,
+    );
 
     match indexer.count().await {
         Ok(n) => tracing::info!(

--- a/klask-rs/src/services/semantic/query.rs
+++ b/klask-rs/src/services/semantic/query.rs
@@ -111,19 +111,26 @@ async fn hydrate_semantic_only(
     let ordered_ids: Vec<Uuid> = dedup_by_file(vector_hits.iter().map(|h| h.file_id));
     let total = ordered_ids.len() as u64;
 
-    // Best (closest) chunk start line per file, to anchor the snippet on the
-    // matched region (vector_hits arrive closest-first, so first-seen wins).
-    let mut best_line: std::collections::HashMap<Uuid, u32> = std::collections::HashMap::new();
+    // Best (closest) chunk per file: its line range anchors/trims the snippet,
+    // and its cosine distance becomes the result score. vector_hits arrive
+    // closest-first, so first-seen wins.
+    let mut best_chunk: std::collections::HashMap<Uuid, &super::store::VectorHit> = std::collections::HashMap::new();
     for hit in &vector_hits {
-        best_line.entry(hit.file_id).or_insert(hit.start_line);
+        best_chunk.entry(hit.file_id).or_insert(hit);
     }
 
     let page_ids: Vec<Uuid> = ordered_ids.iter().skip(query.offset).take(query.limit).copied().collect();
     // fetch_results_by_file_ids preserves input order, so the ranking is kept.
     let mut results = search_service.fetch_results_by_file_ids(&page_ids).await?;
     for result in &mut results {
-        if let Some(line) = best_line.get(&result.file_id) {
-            result.line_number = Some(*line);
+        if let Some(hit) = best_chunk.get(&result.file_id) {
+            result.line_number = Some(hit.start_line);
+            // Replace Tantivy's keyword score (meaningless for a semantic query)
+            // with the cosine similarity of the matched chunk.
+            result.score = similarity_from_distance(hit.distance);
+            // Show the matched chunk, not the whole file (which made semantic
+            // results look unrelated even when the ranking was right).
+            result.content_snippet = snippet_for_chunk(&result.content_snippet, hit.start_line, hit.end_line);
         }
         // Semantic-only: every result came from the vector engine.
         result.match_source = Some(MatchSource::Semantic);
@@ -158,14 +165,35 @@ async fn hybrid_fuse(
     let in_keyword: std::collections::HashSet<Uuid> = keyword_ranking.iter().copied().collect();
     let in_vector: std::collections::HashSet<Uuid> = vector_ranking.iter().copied().collect();
 
+    // Best vector chunk per file (for the snippet range on vector/both hits).
+    let mut best_chunk: std::collections::HashMap<Uuid, &super::store::VectorHit> = std::collections::HashMap::new();
+    for hit in &vector_hits {
+        best_chunk.entry(hit.file_id).or_insert(hit);
+    }
+
     let fused = reciprocal_rank_fusion(&[keyword_ranking, vector_ranking], DEFAULT_RRF_K);
     let total = fused.len() as u64;
+    // Fused RRF score per file, so the response is sorted/scored by the actual
+    // hybrid ranking rather than Tantivy's keyword score.
+    let fused_score: std::collections::HashMap<Uuid, f32> = fused.iter().copied().collect();
 
     let page_ids: Vec<Uuid> = fused.iter().skip(query.offset).take(query.limit).map(|(id, _)| *id).collect();
     // fetch_results_by_file_ids preserves input (fused) order.
     let mut results = search_service.fetch_results_by_file_ids(&page_ids).await?;
     for result in &mut results {
-        result.match_source = Some(match_source(&in_keyword, &in_vector, result.file_id));
+        let source = match_source(&in_keyword, &in_vector, result.file_id);
+        result.match_source = Some(source);
+        if let Some(score) = fused_score.get(&result.file_id) {
+            result.score = *score;
+        }
+        // For results the vector engine matched, anchor + trim the snippet on the
+        // matched chunk; pure-keyword hits keep Tantivy's highlighted snippet.
+        if source != MatchSource::Keyword
+            && let Some(hit) = best_chunk.get(&result.file_id)
+        {
+            result.line_number = Some(hit.start_line);
+            result.content_snippet = snippet_for_chunk(&result.content_snippet, hit.start_line, hit.end_line);
+        }
     }
 
     Ok(SearchResultsWithTotal { results, total, facets: keyword.facets })
@@ -202,6 +230,32 @@ fn match_source(
         // (true, false) and the impossible (false, false) → keyword.
         _ => MatchSource::Keyword,
     }
+}
+
+/// Map a cosine *distance* (0 = identical, 2 = opposite) to a similarity score
+/// in `[0, 1]` for display/sorting, so semantic results carry a meaningful score
+/// instead of Tantivy's keyword score. `1 - distance` is the cosine similarity;
+/// clamped because distance can drift slightly outside `[0, 2]`.
+fn similarity_from_distance(distance: f32) -> f32 {
+    (1.0 - distance).clamp(0.0, 1.0)
+}
+
+/// Trim a file's stored content to the matched chunk's line range so the snippet
+/// shows the semantically-relevant region, not the whole file. Lines are
+/// 1-based and inclusive (matching `ChunkRecord`); out-of-range or empty input
+/// falls back to the original content so we never show nothing.
+fn snippet_for_chunk(content: &str, start_line: u32, end_line: u32) -> String {
+    if content.is_empty() || start_line == 0 || end_line < start_line {
+        return content.to_string();
+    }
+    let start = (start_line as usize).saturating_sub(1);
+    let end = end_line as usize; // inclusive 1-based end == exclusive 0-based end
+    let lines: Vec<&str> = content.lines().collect();
+    if start >= lines.len() {
+        return content.to_string();
+    }
+    let end = end.min(lines.len());
+    lines[start..end].join("\n")
 }
 
 /// Distinct file_ids in first-seen order (a file can contribute several chunks
@@ -374,6 +428,13 @@ mod tests {
             Some(1),
             "snippet should anchor on the matched chunk's start line"
         );
+        // The score must be the cosine similarity (0..=1), not Tantivy's keyword
+        // score — that was the bug making semantic results look meaningless.
+        let score = results.results[0].score;
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "semantic score should be a cosine similarity in [0,1], got {score}"
+        );
     }
 
     #[tokio::test]
@@ -430,6 +491,29 @@ mod tests {
             Some(MatchSource::Semantic),
             "semantic-only results must be tagged Semantic"
         );
+    }
+
+    #[test]
+    fn test_similarity_from_distance() {
+        assert_eq!(super::similarity_from_distance(0.0), 1.0); // identical
+        assert!((super::similarity_from_distance(0.27) - 0.73).abs() < 1e-5);
+        assert_eq!(super::similarity_from_distance(1.5), 0.0); // far → clamped
+        assert_eq!(super::similarity_from_distance(-0.01), 1.0); // drift → clamped
+    }
+
+    #[test]
+    fn test_snippet_for_chunk() {
+        let content = "line1\nline2\nline3\nline4\nline5";
+        // 1-based inclusive range [2,4] → lines 2..4.
+        assert_eq!(super::snippet_for_chunk(content, 2, 4), "line2\nline3\nline4");
+        // Single line.
+        assert_eq!(super::snippet_for_chunk(content, 1, 1), "line1");
+        // End past EOF clamps.
+        assert_eq!(super::snippet_for_chunk(content, 4, 99), "line4\nline5");
+        // Degenerate inputs fall back to full content.
+        assert_eq!(super::snippet_for_chunk(content, 0, 3), content);
+        assert_eq!(super::snippet_for_chunk(content, 9, 10), content);
+        assert_eq!(super::snippet_for_chunk("", 1, 2), "");
     }
 
     #[test]

--- a/klask-rs/src/services/semantic/query.rs
+++ b/klask-rs/src/services/semantic/query.rs
@@ -20,7 +20,7 @@ use super::embedder::EmbeddingProvider;
 use super::fusion::{DEFAULT_RRF_K, reciprocal_rank_fusion};
 use super::indexer::VectorIndexer;
 use super::store::VectorSearchFilters;
-use crate::services::search::{SearchMode, SearchQuery, SearchResultsWithTotal, SearchService};
+use crate::services::search::{MatchSource, SearchMode, SearchQuery, SearchResultsWithTotal, SearchService};
 use anyhow::{Context, Result};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -125,6 +125,8 @@ async fn hydrate_semantic_only(
         if let Some(line) = best_line.get(&result.file_id) {
             result.line_number = Some(*line);
         }
+        // Semantic-only: every result came from the vector engine.
+        result.match_source = Some(MatchSource::Semantic);
     }
 
     let facets = maybe_keyword_facets(search_service, query, page_end).await?;
@@ -150,12 +152,21 @@ async fn hybrid_fuse(
     let keyword_ranking: Vec<Uuid> = dedup_by_file(keyword.results.iter().map(|r| r.file_id));
     let vector_ranking: Vec<Uuid> = dedup_by_file(vector_hits.iter().map(|h| h.file_id));
 
+    // Membership sets for per-result provenance (the UI badge): a file can be a
+    // keyword hit, a vector hit, or both. Built before the rankings are moved
+    // into the fusion call.
+    let in_keyword: std::collections::HashSet<Uuid> = keyword_ranking.iter().copied().collect();
+    let in_vector: std::collections::HashSet<Uuid> = vector_ranking.iter().copied().collect();
+
     let fused = reciprocal_rank_fusion(&[keyword_ranking, vector_ranking], DEFAULT_RRF_K);
     let total = fused.len() as u64;
 
     let page_ids: Vec<Uuid> = fused.iter().skip(query.offset).take(query.limit).map(|(id, _)| *id).collect();
     // fetch_results_by_file_ids preserves input (fused) order.
-    let results = search_service.fetch_results_by_file_ids(&page_ids).await?;
+    let mut results = search_service.fetch_results_by_file_ids(&page_ids).await?;
+    for result in &mut results {
+        result.match_source = Some(match_source(&in_keyword, &in_vector, result.file_id));
+    }
 
     Ok(SearchResultsWithTotal { results, total, facets: keyword.facets })
 }
@@ -175,6 +186,22 @@ async fn maybe_keyword_facets(
     facet_query.offset = 0;
     facet_query.limit = page_end.max(1);
     Ok(search_service.search(facet_query).await?.facets)
+}
+
+/// Classify a fused result by which engine(s) it appeared in, for the UI badge.
+/// A file present in both rankings is `Both`; otherwise it came from whichever
+/// single engine contains it (every fused id is in at least one).
+fn match_source(
+    in_keyword: &std::collections::HashSet<Uuid>,
+    in_vector: &std::collections::HashSet<Uuid>,
+    file_id: Uuid,
+) -> MatchSource {
+    match (in_keyword.contains(&file_id), in_vector.contains(&file_id)) {
+        (true, true) => MatchSource::Both,
+        (false, true) => MatchSource::Semantic,
+        // (true, false) and the impossible (false, false) → keyword.
+        _ => MatchSource::Keyword,
+    }
 }
 
 /// Distinct file_ids in first-seen order (a file can contribute several chunks
@@ -376,6 +403,46 @@ mod tests {
             results.results[0].file_id, auth,
             "doc winning both engines must rank first under RRF"
         );
+        // auth matched lexically ("login") *and* semantically ("authentication").
+        assert_eq!(
+            results.results[0].match_source,
+            Some(MatchSource::Both),
+            "a doc hit by both engines must be tagged Both for the UI badge"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_semantic_mode_tags_results_semantic() {
+        let auth = Uuid::new_v4();
+        let (search, indexer, provider, _dir) =
+            setup(&[Doc { file_id: auth, path: "auth.rs", content: "fn login() { /* authentication */ }" }]).await;
+
+        let results = semantic_search(
+            &search,
+            &provider,
+            &indexer,
+            query("authentication", SearchMode::Semantic),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            results.results[0].match_source,
+            Some(MatchSource::Semantic),
+            "semantic-only results must be tagged Semantic"
+        );
+    }
+
+    #[test]
+    fn test_match_source_classification() {
+        use std::collections::HashSet;
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let c = Uuid::new_v4();
+        let kw: HashSet<Uuid> = [a, b].into_iter().collect();
+        let vec: HashSet<Uuid> = [b, c].into_iter().collect();
+        assert_eq!(match_source(&kw, &vec, a), MatchSource::Keyword);
+        assert_eq!(match_source(&kw, &vec, b), MatchSource::Both);
+        assert_eq!(match_source(&kw, &vec, c), MatchSource::Semantic);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Phase 5 of the [hybrid semantic search plan](docs/SEMANTIC_SEARCH_PLAN.md): the **frontend** (plan §6) plus the small backend pieces it needs. A no-op when semantic search is off.

Stacked on #127 (Phase 4) — review base is `semantic-search-phase-3`, so the diff is Phase 5 only.

## What's new

### Backend
- **Capabilities endpoint** — authenticated (non-admin) `GET /api/search/capabilities` → `{ semantic_enabled }`, true only when the feature is built, the model loaded and the vector store opened. The regular search UI needs this to decide whether to show the engine toggle (the admin `status` endpoint is admin-only).
- **Match provenance** — new `MatchSource` (`keyword`|`semantic`|`both`) on `SearchResult`, populated in the query path: semantic-only tags every hit `Semantic`; hybrid tags each fused file by membership in the keyword/vector rankings (`Both` when in both). Serialized with `skip_serializing_if = "Option::is_none"` so the **keyword response is byte-for-byte unchanged**.

### Frontend
- **Engine selector** (Keyword | Hybrid | Semantic) in `SearchPageV3`, shown only when the server reports semantic search is available, persisted in the URL as `mode=` (omitted when keyword → clean, backward-compatible URLs), wired into the existing `mode` param of `useMultiSelectSearch`. Orthogonal to the fuzzy/regex/case toggles (those choose *how* the keyword engine matches; this chooses *which* engine answers). Per-mode tooltips.
- **`useSearchCapabilities`** hook — cached for the process lifetime; degrades to hidden if the endpoint is unreachable.
- **Per-result match-source badge** in hybrid/semantic mode (keyword / semantic / both) for at-a-glance trust/debugging.
- The admin **"Semantic Index" card** shipped in Phase 3; nothing further needed here.

## Decisions (confirmed)

- **Result badges**: added real per-result provenance to the backend (not just a header indicator).
- **Availability detection**: added a dedicated public capabilities endpoint (not "always show the toggle").

## Verification

- `cargo clippy --features semantic-search --all-targets -D warnings` and `cargo clippy --all-targets -D warnings` — clean
- `cargo test --features semantic-search` and `cargo test` — 0 failures both modes
- Frontend `vitest run` — 956/956; `tsc --noEmit` clean
- No new ESLint errors (pre-existing count unchanged vs base)

## Out of scope (Phase 6)

- MCP `search_code` `mode` param (default hybrid for agents)
- IVF_PQ ANN index; latency P95 / recall@10 eval and tuning