### PR TITLE
Feature/erreur snippet to html

### DIFF
--- a/klask-rs/src/services/search.rs
+++ b/klask-rs/src/services/search.rs
@@ -34,6 +34,23 @@ const SIZE_BUCKETS: &[(&str, Option<u64>, Option<u64>)] = &[
     ("> 1 MB", Some(1024 * 1024), None),
 ];
 
+/// Convert octet to another unit
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.2} Go", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} Mo", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} Ko", bytes as f64 / KB as f64)
+    } else {
+        format!("{} octets", bytes)
+    }
+}
+
 /// Builds a regex pattern with inline flags based on the provided flags string.
 ///
 /// Supported flags (similar to regex101.com):
@@ -1205,7 +1222,70 @@ impl SearchService {
         // Generate the snippet with HTML highlighting using Tantivy's SnippetGenerator
         // The snippet generator uses the non-fuzzy query, so it can properly highlight matches
         let snippet = generator.snippet_from_doc(doc);
-        let highlighted_html = snippet.to_html();
+
+        let highlighted_html = std::panic::catch_unwind(|| snippet.to_html())
+           .unwrap_or_else(|_| {
+
+            // In case of an error in the function to_html, the information is displayed on the document on the log.
+            let file_id = doc.get_first(self.fields.file_id)
+                .and_then(|v| v.as_str())
+                .unwrap_or("[ID inconnu]");
+
+            let doc_name = doc.get_first(self.fields.file_name)
+                .and_then(|v| v.as_str())
+                .unwrap_or("[Nom inconnu]");
+
+            let file_path = doc.get_first(self.fields.file_path)
+                .and_then(|v| v.as_str())
+                .unwrap_or("[Chemin inconnu]");
+
+            let repository = doc.get_first(self.fields.repository)
+                .and_then(|v| v.as_str())
+                .unwrap_or("[Dépôt inconnu]");
+
+            let project = doc.get_first(self.fields.project)
+                .and_then(|v| v.as_str())
+                .unwrap_or("[project inconnu]");
+
+            let version = doc.get_first(self.fields.version)
+                .and_then(|v| v.as_str())
+                .unwrap_or("[version inconnue]");
+
+            let _extension = doc.get_first(self.fields.extension)
+                .and_then(|v| v.as_str())
+                .unwrap_or("[extension inconnue]");
+
+            let _size = if let Some(compact_value) = doc.get_first(self.fields.size) {
+                if let Some(u64_value) = compact_value.as_u64() {
+                     format_size(u64_value)
+                } else {
+                    "[Taille inconnue (pas u64)]".to_string()
+                }
+            } else {
+                "[Taille inconnue]".to_string()
+            };
+
+           let doc_content_preview = doc.get_first(self.fields.content)
+                .and_then(|v| v.as_str())
+                .map(|s| s.chars().take(50).collect::<String>())
+                .unwrap_or_else(|| "[Contenu vide]".to_string());
+
+            // File information
+            eprintln!(
+                "  Erreur HTML pour le document:\n\
+                - ID: {}\n\
+                - Nom: {}\n\
+                - Chemin: {}\n\
+                - Dépôt: {}\n\
+                - Project: {}\n\
+                - Version: {}\n\
+                - Extension: {}\n\
+                - Size: {} octets\n\
+                - Contenu: '{}...'",
+                file_id, doc_name, file_path, repository, project, version, _extension, _size, doc_content_preview
+            );
+            String::new() // Force le fallback
+        });
 
         // Extract clean search terms from query for line number calculation (remove fuzzy/wildcard chars)
         let clean_terms: Vec<String> = query

--- a/klask-rs/tests/mcp_test.rs
+++ b/klask-rs/tests/mcp_test.rs
@@ -44,6 +44,16 @@ async fn setup_test_server() -> Result<(TestServer, AppState, TempDir)> {
             allow_registration: true,
         },
         cors: CorsConfig { allowed_origins: vec![] },
+        semantic: klask_rs::config::SemanticSearchConfig {
+            enabled: false,
+            model: "jinaai/jina-embeddings-v2-base-code".to_string(),
+            cache_dir: "./models".to_string(),
+            vector_store_dir: "./vector-index".to_string(),
+            chunk_max_lines: 60,
+            chunk_overlap_lines: 15,
+            batch_size: 32,
+            queue_capacity: 1000,
+        },
     };
 
     let progress_tracker = Arc::new(ProgressTracker::new());
@@ -55,6 +65,7 @@ async fn setup_test_server() -> Result<(TestServer, AppState, TempDir)> {
         progress_tracker.clone(),
         encryption_service.clone(),
         config.crawler.temp_dir.clone(),
+        None,
     )?);
 
     let app_state = AppState {
@@ -63,6 +74,8 @@ async fn setup_test_server() -> Result<(TestServer, AppState, TempDir)> {
         crawler_service,
         progress_tracker,
         scheduler_service: None,
+        semantic_embedder: None,
+        semantic_indexer: None,
         jwt_service,
         encryption_service,
         config,


### PR DESCRIPTION
Certaines recherches n'aboutissent pas et se termine avec une erreur 
<img width="1227" height="607" alt="image" src="https://github.com/user-attachments/assets/1b939490-801e-41a7-aaab-fd37fdf044e5" />

Dans le log de klask-backend, on a la trace ci-dessous 
> klask-backend   | thread 'tokio-rt-worker' (1017) panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-0.25.0/src/snippet/mod.rs:155:57:
> klask-backend   | end byte index 18446744073709551598 is out of bounds for string of length 293
> klask-backend   | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
> klask-backend   | 2026-06-23T06:49:05.607004Z ERROR klask_rs::api::search: Search failed: Search thread panicked: task 53662 panicked with message "end byte index 18446744073709551598 is out of bounds for string of length 293"
> klask-backend   | 2026-06-23T06:49:05.607493Z ERROR tower_http::trace::on_failure: response failed classification=Status code: 500 Internal Server Error latency=34 ms

Si on positionne RUST_BACKTRACE=1 pour avoir la pile d'erreur, on peut voir qu'il y a une exception au niveau du code Tantivy lors de la conversion en HTML

> klask-backend-numih  | thread 'tokio-rt-worker' (38) panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-0.25.0/src/snippet/mod.rs:155:57:
klask-backend-numih  | end byte index 18446744073709551598 is out of bounds of `Extracteur;
klask-backend-numih  | import fr.sib.yyy.securite.cnx.spring.extension.erreurs.ErreurAuthenticationRestHandler;
klask-backend-numih  | import fr.sib.yyy.securite.cnx.spring.extension.jwt.session.YyyHttpSessionSecurityFilter;
klask-backend-numih  | import fr.sib.yyy.securite.cnx.spring.extension.j`[...]
klask-backend-numih  | stack backtrace:
klask-backend-numih  |    0:     0x558735eb0efa - <<std[e28293b1aa0f68bd]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[c1f1a4ba060b9bfa]::fmt::Display>::fmt
klask-backend-numih  |    1:     0x558735ecaeea - core[c1f1a4ba060b9bfa]::fmt::write
klask-backend-numih  |    2:     0x558735eb70c2 - <std[e28293b1aa0f68bd]::sys::stdio::unix::Stderr as std[e28293b1aa0f68bd]::io::Write>::write_fmt
klask-backend-numih  |    3:     0x558735e8a68f - std[e28293b1aa0f68bd]::panicking::default_hook::{closure#0}
klask-backend-numih  |    4:     0x558735ea78e1 - std[e28293b1aa0f68bd]::panicking::default_hook
klask-backend-numih  |    5:     0x558735ea7b5b - std[e28293b1aa0f68bd]::panicking::panic_with_hook
klask-backend-numih  |    6:     0x558735e8a748 - std[e28293b1aa0f68bd]::panicking::panic_handler::{closure#0}
klask-backend-numih  |    7:     0x558735e81649 - std[e28293b1aa0f68bd]::sys::backtrace::__rust_end_short_backtrace::<std[e28293b1aa0f68bd]::panicking::panic_handler::{closure#0}, !>
klask-backend-numih  |    8:     0x558735e8b92d - __rustc[b7974e8690430dd9]::rust_begin_unwind
klask-backend-numih  |    9:     0x558735ecb7ac - core[c1f1a4ba060b9bfa]::panicking::panic_fmt
klask-backend-numih  |   10:     0x558735ecb081 - core[c1f1a4ba060b9bfa]::str::slice_error_fail_rt
klask-backend-numih  |   11:     0x558735ecaf4a - core[c1f1a4ba060b9bfa]::str::slice_error_fail
klask-backend-numih  |   12:     0x558735222ce8 - tantivy::snippet::Snippet::to_html::h06b5e714b7cdcb0e
klask-backend-numih  |   13:     0x55873503a5b7 - klask_rs::services::search::SearchService::search_blocking::h71ec726bb964985c
klask-backend-numih  |   14:     0x558734e3be9a - <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll::he6dca370db97c4f4
klask-backend-numih  |   15:     0x558734d76147 - tokio::runtime::task::core::Core<T,S>::poll::h4dc513a9af06d282
klask-backend-numih  |   16:     0x55873506acb8 - tokio::runtime::task::harness::Harness<T,S>::poll::h0cb4c8785072948b
klask-backend-numih  |   17:     0x558735e5d1db - tokio::runtime::blocking::pool::Inner::run::h2d4e754908c3c965
klask-backend-numih  |   18:     0x558735e530c3 - std::sys::backtrace::__rust_begin_short_backtrace::hd3fe491900c43512
klask-backend-numih  |   19:     0x558735e5e5a2 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h4c43b178a5030f18
klask-backend-numih  |   20:     0x558735eb02bf - <std[e28293b1aa0f68bd]::sys::thread::unix::Thread>::new::thread_start
klask-backend-numih  |   21:     0x7f9226fbbb7b - <unknown>
klask-backend-numih  |   22:     0x7f9227039630 - __clone
klask-backend-numih  |   23:                0x0 - <unknown>

==> **solution proposée** :  catcher l'erreur si il y en a une lors de la conversion et dans ce cas afficher les informations sur le document qui a posé problème

Exemple de traces : 

> klask-backend-numih  | thread 'tokio-rt-worker' (82) panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-0.25.0/src/snippet/mod.rs:155:57:
klask-backend-numih  | end byte index 18446744073709551598 is out of bounds for string of length 293
klask-backend-numih  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
klask-backend-numih  |   Erreur HTML pour le document:
klask-backend-numih  | - ID: db8208e4-f167-4f08-87df-780e48b3f485
klask-backend-numih  | - Nom: JwtSpringSecurityConfigurer.java
klask-backend-numih  | - Chemin: securite-cnx-SA/src/main/java/fr/sib/yyy/securite/cnx/spring/extension/jwt/JwtSpringSecurityConfigurer.java
klask-backend-numih  | - Dépôt: XXXX
klask-backend-numih  | - Project: yyy/wwww/zzz
klask-backend-numih  | - Version: main
klask-backend-numih  | - Extension: java
klask-backend-numih  | - Size: 8.95 Ko octets
klask-backend-numih  | - Contenu: 'package fr.sib.yyy.securite.cnx.spring.extensi...'